### PR TITLE
Java serializer is replaced by Kryo library

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To your SBT `build.sbt` add the following lines:
 
 ```scala
 // redis-server cache
-libraryDependencies += "com.github.karelcemus" %% "play-redis" % "1.1.0"
+libraryDependencies += "com.github.karelcemus" %% "play-redis" % "1.2.0"
 
 // repository with the Brando connector
 resolvers += "Brando Repository" at "http://chrisdinn.github.io/releases/"
@@ -215,6 +215,14 @@ Nevertheless, this module **replaces** the EHCache and it is not intended to use
 
 
 ## Changelog
+
+### 1.2.0
+
+Since Akka 2.4.1, default JavaSerializer is [considered inefficient for production use](https://github.com/akka/akka/pull/18552). 
+Since this release, play-redis uses [kryo serializer](https://github.com/romix/akka-kryo-serialization) claiming
+better performance and reduced output stream. *To keep it simple*, it uses `akka.actor.kryo.idstrategy`
+set to `default`, which is *considered the slowest alternative*. However, it *does not require any further configuration*. To optimize
+serialization, please see documentation for `idstrategy` option in kryo library.
 
 ### 1.1.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,14 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-cache" % playVersion % "provided" exclude("net.sf.ehcache", "ehcache-core"),
   // redis connector - NOTE: not published yet
   "com.digital-achiever" %% "brando" % brandoVersion,
+  // Akka Serializer, efficient than default Java implementation
+  "com.github.romix.akka" %% "akka-kryo-serialization" % "0.4.0",
   // test framework
   "org.specs2" %% "specs2-core" % specs2Version % "test",
   // test module for play framework
-  "com.typesafe.play" %% "play-test" % playVersion % "test"
+  "com.typesafe.play" %% "play-test" % playVersion % "test",
+  // logger for tests
+  "org.slf4j" % "slf4j-simple" % "1.7.16" % "test"
 )
 
 resolvers ++= Seq(

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -35,9 +35,56 @@ akka {
   log-dead-letters = off
   akka.log-dead-letters-during-shutdown = off
 
+  # enables kryo settings customization
+  extensions = ["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
+
   actor {
+    serializers {
+      # kryo is much performant than default java serializer, it produces
+      # smaller output stream in shorter time
+      # since Akka 2.4.x, it deprecates the default Java serializer as not
+      # optimal for the production use
+      kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
+    }
     serialization-bindings {
-      "scala.collection.immutable.List" = java
+      "java.io.Serializable" = kryo
+      "scala.collection.immutable.List" = kryo
+    }
+    # configuration of the serialization library
+    kryo {
+      # The transformations that have be done while serialization
+      # Supported transformations: compression and encryption
+      # accepted values(comma separated if multiple): off | lz4 | deflate | aes
+      # Transformations occur in the order they are specified
+      post-serialization-transformations = "off"
+
+      # Possible values for idstrategy are:
+      # default, explicit, incremental, automatic
+      #
+      # default - slowest and produces bigger serialized representation.
+      # Contains fully-qualified class names (FQCNs) for each class. Note
+      # that selecting this strategy does not work in version 0.3.2, but
+      # is available from 0.3.3 onward.
+      #
+      # explicit - fast and produces compact serialized representation.
+      # Requires that all classes that will be serialized are pre-registered
+      # using the "mappings" and "classes" sections. To guarantee that both
+      # sender and receiver use the same numeric ids for the same classes it
+      # is advised to provide exactly the same entries in the "mappings"
+      # section.
+      #
+      # incremental - fast and produces compact serialized representation.
+      # Support optional pre-registering of classes using the "mappings"
+      # and "classes" sections. If class is not pre-registered, it will be
+      # registered dynamically by picking a next available id To guarantee
+      # that both sender and receiver use the same numeric ids for the same
+      # classes it is advised to pre-register them using at least the "classes" section.
+      #
+      # automatic -  use the pre-registered classes with fallback to FQCNs
+      # Contains fully-qualified class names (FQCNs) for each non pre-registered
+      # class in the "mappings" and "classes" sections. That this strategy was
+      # added in version 0.4.1 and will not work with the previous versions
+      idstrategy = "default"
     }
   }
 }

--- a/src/main/scala/play/api/cache/redis/AkkaSerializer.scala
+++ b/src/main/scala/play/api/cache/redis/AkkaSerializer.scala
@@ -24,7 +24,7 @@ trait AkkaSerializer {
 
   protected def system: ActorSystem
 
-  /** in production mode serializer is just one, in development mode it is reloaded */
+  /** serializer dispatcher used to serialize the objects into bytes */
   private val serializer: Serialization = SerializationExtension( system )
 
   /** encode given object into string */

--- a/src/main/scala/play/api/cache/redis/AkkaSerializer.scala
+++ b/src/main/scala/play/api/cache/redis/AkkaSerializer.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util._
 
-import play.api.{Application, Logger}
+import play.api.Logger
 
 import akka.actor.ActorSystem
 import akka.serialization._
@@ -18,9 +18,6 @@ trait AkkaSerializer {
 
   /** logger handler */
   protected def log: Logger
-
-  /** current application */
-  protected implicit def application: Application
 
   protected def system: ActorSystem
 

--- a/src/main/scala/play/api/cache/redis/Cache.scala
+++ b/src/main/scala/play/api/cache/redis/Cache.scala
@@ -11,15 +11,15 @@ import akka.actor.ActorSystem
 trait CacheApi extends InternalCacheApi[ Builders.Identity ]
 
 @Singleton
-class SyncRedis @Inject( )( implicit application: Application, lifecycle: ApplicationLifecycle, configuration: Configuration, system: ActorSystem )
-  extends RedisCache( )( Builders.SynchronousBuilder, application, lifecycle, configuration, system ) with CacheApi with play.api.cache.CacheApi
+class SyncRedis @Inject( )( implicit lifecycle: ApplicationLifecycle, configuration: Configuration, system: ActorSystem )
+  extends RedisCache( )( Builders.SynchronousBuilder, lifecycle, configuration, system ) with CacheApi with play.api.cache.CacheApi
 
 /** Asynchronous non-blocking implementation of the connection to the redis database */
 trait CacheAsyncApi extends InternalCacheApi[ Builders.Future ]
 
 @Singleton
-class AsyncRedis @Inject( )( implicit application: Application, lifecycle: ApplicationLifecycle, configuration: Configuration, system: ActorSystem )
-  extends RedisCache( )( Builders.AsynchronousBuilder, application, lifecycle, configuration, system ) with CacheAsyncApi
+class AsyncRedis @Inject( )( implicit lifecycle: ApplicationLifecycle, configuration: Configuration, system: ActorSystem )
+  extends RedisCache( )( Builders.AsynchronousBuilder, lifecycle, configuration, system ) with CacheAsyncApi
 
 /** Java version of play.api.CacheApi */
 trait JavaCacheApi extends play.cache.CacheApi {

--- a/src/main/scala/play/api/cache/redis/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/RedisCache.scala
@@ -17,7 +17,6 @@ import brando._
 class RedisCache[ Result[ _ ] ](
 
   implicit builder: Builders.ResultBuilder[ Result ],
-  protected val application: Application,
   lifecycle: ApplicationLifecycle,
   protected val configuration: Configuration,
   protected val system: ActorSystem

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.1-SNAPSHOT"
+version in ThisBuild := "1.2.0-SNAPSHOT"


### PR DESCRIPTION
Since Akka 2.4.1, default JavaSerializer is [considered inefficient for production use](https://github.com/akka/akka/pull/18552). 
Since this release, play-redis uses [kryo serializer](https://github.com/romix/akka-kryo-serialization) claiming
better performance and reduced output stream. *To keep it simple*, it uses `akka.actor.kryo.idstrategy`
set to `default`, which is *considered the slowest alternative*. However, it *does not require any further configuration*. To optimize
serialization, please see documentation for `idstrategy` option in kryo library.