### PR TITLE
Renamed EnvironmentConfiguration to ConnectionString

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ scala:
 branches:
   only:
   - master
+  - 1.3.x
 cache:
   directories:
   - $HOME/.ivy2/cache

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To your SBT `build.sbt` add the following lines:
 
 ```scala
 // redis-server cache
-libraryDependencies += "com.github.karelcemus" %% "play-redis" % "1.2.0"
+libraryDependencies += "com.github.karelcemus" %% "play-redis" % "1.3.0"
 
 // repository with the Brando connector
 resolvers += "Brando Repository" at "http://chrisdinn.github.io/releases/"
@@ -165,11 +165,12 @@ There is already default configuration but it can be overwritten in your `conf/a
 
 In various environments there are various sources of the connection string defining how to connect to Redis instance.
 For example, at localhost we are interested in direct definition of host and port in the `application.conf` file.
-However, this approach does not fit all environments. For example, Heroku supplies `REDIS_URL` environment variable
+However, this approach does not fit all environments. For example, Heroku supplies `REDISCLOUD_URL` environment variable
 defining the connection string. To resolve this diversity, the library expects an implementation of the `Configuration`
 trait available through DI. By default, it enables `static` configuration source, i.e., it reads the settings from the
 static configuration file. Another supplied configuration reader is `env`, which reads the environment variable such as
-`REDIS_URL` but the name is configurable. To disable built-in providers you are free to set `custom` and supply your
+`REDIS_URL` but the variable name is configurable. To easy use on Heroku, we also provide `heroku` configuration
+profile expecting `REDISCLOUD_URL` variable. To disable built-in providers you are free to set `custom` and supply your
 own implementation of the `Configuration` trait.
 
 ### Running on Heroku
@@ -179,7 +180,7 @@ To enable redis cache on Heroku we have to do the following steps:
  1. add library into application dependencies
  2. enable `RedisCacheModule`
  3. disable `EhCacheModule`
- 4. set `play.cache.redis.configuration: env`
+ 4. set `play.cache.redis.configuration: heroku`, which expects `REDISCLOUD_URL` environment variable
  5. done, we can run it and use any of 3 provided interfaces
 
 ### Custom configuration source
@@ -211,7 +212,7 @@ Nevertheless, this module **replaces** the EHCache and it is not intended to use
 
 | play framework  | play-redis     |
 |-----------------|---------------:|
-| 2.5.x           | 1.2.0          |
+| 2.5.x           | 1.3.0          |
 | 2.4.x           | 1.0.0          |
 | 2.3.x           | 0.2.1          |
 
@@ -219,6 +220,16 @@ Nevertheless, this module **replaces** the EHCache and it is not intended to use
 </center>
 
 ## Changelog
+
+### [:link: 1.3.0](https://github.com/KarelCemus/play-redis/tree/1.3.0) (Possibly breaking)
+
+Major internal code refactoring, library has been modularized into several packages.
+However, **public API remained unchanged**, although its implementation significantly
+changed.
+
+Added `heroku` configuration profile.
+
+
 
 ### [:link: 1.2.0](https://github.com/KarelCemus/play-redis/tree/1.2.0)
 

--- a/src/main/scala/play/api/cache/redis/configuration/ConfigurationFile.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/ConfigurationFile.scala
@@ -11,7 +11,7 @@ import play.api.cache.redis.Configuration
   * located in there. This is default configuration provider. It expects all settings under the 'play.cache.redis' node.
   */
 @Singleton
-class StaticConfiguration extends Configuration {
+private[ redis ] class ConfigurationFile extends Configuration {
 
   import scala.language.implicitConversions
 

--- a/src/main/scala/play/api/cache/redis/configuration/ConnectionString.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/ConnectionString.scala
@@ -7,7 +7,7 @@ import javax.inject.Singleton
  * the connection string. This configuration is often used by PaaS environments.
  */
 @Singleton
-class EnvironmentConfiguration(
+class ConnectionString(
 
   /** host with redis server */
   override val host: String,
@@ -18,4 +18,4 @@ class EnvironmentConfiguration(
   /** authentication password */
   override val password: Option[ String ]
 
-) extends StaticConfiguration
+) extends ConfigurationFile

--- a/src/main/scala/play/api/cache/redis/configuration/ConnectionStringProvider.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/ConnectionStringProvider.scala
@@ -8,17 +8,17 @@ import javax.inject.Provider
  *
  * @param variable name of the variable with the connection string in the environment
  */
-class EnvironmentConfigurationProvider( variable: String ) extends Provider[ EnvironmentConfiguration ] {
+class ConnectionStringProvider( variable: String ) extends Provider[ ConnectionString ] {
 
   /** expected format of the environment variable */
   private val REDIS_URL = "redis://((?<user>[^:]+):(?<password>[^@]+)@)?(?<host>[^:]+):(?<port>[0-9]+)".r( "auth", "user", "password", "host", "port" )
 
   /** read environment url or throw an exception */
-  override def get( ): EnvironmentConfiguration = url.map( REDIS_URL.findFirstMatchIn ) match {
+  override def get( ): ConnectionString = url.map( REDIS_URL.findFirstMatchIn ) match {
     // read the environment variable and fill missing information from the local configuration file
-    case Some( Some( matcher ) ) => new EnvironmentConfiguration( matcher.group( "host" ), matcher.group( "port" ).toInt, Option( matcher.group( "password" ) ) )
+    case Some( Some( matcher ) ) => new ConnectionString( matcher.group( "host" ), matcher.group( "port" ).toInt, Option( matcher.group( "password" ) ) )
     // value is defined but not in the expected format
-    case Some( None ) => throw new IllegalArgumentException( s"Unexpected value in the environment variable '$variable'. Expected format is 'redis://[user:password@]host:port'." )
+    case Some( None ) => throw new IllegalArgumentException( s"Unexpected value where the connection string expected in environment variable '$variable'. Expected format is 'redis://[user:password@]host:port'." )
     // variable is missing
     case None => throw new IllegalArgumentException( s"Expected environment variable '$variable' is missing. Expected value is 'redis://[user:password@]host:port'." )
   }

--- a/src/main/scala/play/api/cache/redis/connector/RedisConnectorImpl.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisConnectorImpl.scala
@@ -1,6 +1,6 @@
 package play.api.cache.redis.connector
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -25,6 +25,7 @@ import brando.{Ok, Pong}
   * @param configuration connection settings
   * @author Karel Cemus
   */
+@Singleton
 private [ connector ] class RedisConnectorImpl @Inject( )( redis: RedisActor, serializer: AkkaSerializer, configuration: Configuration )( implicit system: ActorSystem ) extends RedisConnector {
 
   // implicit ask timeout

--- a/src/main/scala/play/api/cache/redis/exception/exceptions.scala
+++ b/src/main/scala/play/api/cache/redis/exception/exceptions.scala
@@ -36,3 +36,10 @@ class UnexpectedResponseException( key: Option[ String ], command: String ) exte
   * @author Karel Cemus
   */
 class SerializationException( value: Any, message: String ) extends RedisException( message )
+
+/**
+  * Indicates invalid module configuration
+  *
+  * @author Karel Cemus
+  */
+class ConfigurationException( message: String ) extends RedisException( message )

--- a/src/main/scala/play/api/cache/redis/exception/package.scala
+++ b/src/main/scala/play/api/cache/redis/exception/package.scala
@@ -26,4 +26,7 @@ package object exception {
 
   def failed( key: Option[ String ], command: String, cause: Throwable ): Nothing =
     throw new ExecutionFailedException( key, command, cause )
+
+  def invalidConfiguration( message: String ): Nothing =
+    throw new ConfigurationException( message )
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -3,3 +3,6 @@
 # ==================
 # disables warning
 akka.actor.warn-about-java-serializer-usage = off
+
+# connection timeout in milliseconds
+play.cache.redis.timeout:    3s

--- a/src/test/scala/play/api/cache/redis/ConfigurationSpec.scala
+++ b/src/test/scala/play/api/cache/redis/ConfigurationSpec.scala
@@ -2,7 +2,7 @@ package play.api.cache.redis
 
 import scala.concurrent.duration._
 
-import play.api.cache.redis.configuration.{EnvironmentConfigurationProvider, StaticConfiguration}
+import play.api.cache.redis.configuration.{ConnectionStringProvider, ConfigurationFile}
 
 import org.specs2.mutable.Specification
 
@@ -13,7 +13,7 @@ class ConfigurationSpec extends Specification {
 
   "Local configuration" should {
 
-    val configuration = new StaticConfiguration( )
+    val configuration = new ConfigurationFile( )
 
     "read host" in {
       configuration.host must beEqualTo( "localhost" )
@@ -42,7 +42,7 @@ class ConfigurationSpec extends Specification {
 
   "Heroku configuration" should {
 
-    val configuration = new EnvironmentConfigurationProvider( "undefined" ) {
+    val configuration = new ConnectionStringProvider( "undefined" ) {
       override protected def url = Some( "redis://h:my-password@redis.server:1234" )
     }.get( )
 
@@ -71,7 +71,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "without password" in {
-      new EnvironmentConfigurationProvider( "undefined" ) {
+      new ConnectionStringProvider( "undefined" ) {
         override protected def url = Some( "redis://redis.server:1234" )
       }.get( ).password must beNone
     }

--- a/src/test/scala/play/api/cache/redis/ConfigurationSpec.scala
+++ b/src/test/scala/play/api/cache/redis/ConfigurationSpec.scala
@@ -32,7 +32,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "read timeout" in {
-      configuration.timeout must beEqualTo( 1.second )
+      configuration.timeout must beEqualTo( 3.second )
     }
 
     "read password" in {
@@ -63,7 +63,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "read timeout" in {
-      configuration.timeout must beEqualTo( 1.second )
+      configuration.timeout must beEqualTo( 3.second )
     }
 
     "read password" in {

--- a/src/test/scala/play/api/cache/redis/Redis.scala
+++ b/src/test/scala/play/api/cache/redis/Redis.scala
@@ -30,7 +30,7 @@ trait Synchronization {
 
   /** waits for future responses and returns them synchronously */
   protected implicit class Synchronizer[ T ]( future: AsynchronousResult[ T ] ) {
-    def sync = Await.result( future, 1.second )
+    def sync = Await.result( future, 3.second )
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1-SNAPSHOT"
+version in ThisBuild := "1.3.0-SNAPSHOT"


### PR DESCRIPTION
- configuration module produces exceptions instead of warning logs
- introduced heroku profile
- added 1.3.0 readme
- bumped to 1.3.0-SNAPSHOT