### PR TITLE
Support of Redis sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,42 @@ class MyController @Inject() ( cache: CacheApi ) {
 }
 ```
 
+
+
+**Example of Sets:**
+
+```scala
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import play.api.cache.redis.CacheApi
+
+class MyController @Inject() ( cache: CacheApi ) {
+
+  // enables Set operations
+  // Scala wrapper over the set at this key
+  cache.set[ String ]( "my-set" )
+
+  // get the whole set
+  cache.set[ String ]( "my-set" ).toSet
+
+  // add values into the set
+  cache.set[ String ]( "my-set" ).add( "ABC", "EDF" )
+
+  // test existence in the set
+  cache.set[ String ]( "my-set" ).contains( "ABC" )
+
+  // size of the set
+  cache.set[ String ]( "my-set" ).size
+  cache.set[ String ]( "my-set" ).isEmpty
+  cache.set[ String ]( "my-set" ).nonEmpty
+
+  // remove the value
+  cache.set[ String ]( "my-set" ).remove( "ABC" )
+}
+```
+
 ## Checking operation result
 
 Regardless of current API, all operations throw an exception when fail. Consequently,
@@ -316,6 +352,8 @@ However, **public API remained unchanged**, although its implementation signific
 changed.
 
 Implemented [Scala wrapper](src/main/scala/play/api/cache/redis/RedisList.scala) over List API to use [Redis Lists](https://redis.io/topics/data-types#lists).
+
+Implemented [Scala wrapper](src/main/scala/play/api/cache/redis/RedisSet.scala) over Set API to use [Redis Sets](https://redis.io/topics/data-types#sets).
 
 Added `heroku` and `heroku-cloud` configuration profiles simplifying [running on Heroku](#running-on-heroku).
 

--- a/src/main/scala/play/api/cache/redis/CacheApi.scala
+++ b/src/main/scala/play/api/cache/redis/CacheApi.scala
@@ -186,6 +186,15 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     * @return Scala wrapper
     */
   def list[ T: ClassTag ]( key: String ): RedisList[ T, Result ]
+
+  /**
+    * Scala wrapper around Redis sorted set-related commands. This simplifies use of the sets.
+    *
+    * @param key the key storing the set
+    * @tparam T type of elements within the set
+    * @return Scala wrapper
+    */
+  def set[ T: ClassTag ]( key: String ): RedisSet[ T, Result ]
 }
 
 /** Synchronous and blocking implementation of the connection to the redis database */

--- a/src/main/scala/play/api/cache/redis/RedisConnector.scala
+++ b/src/main/scala/play/api/cache/redis/RedisConnector.scala
@@ -230,4 +230,82 @@ private[ redis ] trait RedisConnector {
     * @return promise
     */
   def listTrim( key: String, start: Int, end: Int ): Future[ Unit ]
+
+  /**
+    * Adds a member to a sorted set, or update its score if it already exists.
+    *
+    * @note If a specified member is already a member of the sorted set, the score is updated and
+    *       the element reinserted at the right position to ensure the correct ordering.
+    * @note The score values should be the string representation of a double precision floating point number.
+    *       +inf and -inf values are valid values as well.
+    * @note Time complexity: O(log(N)) for each item added, where N is the number of elements in the sorted set.
+    * @param key   cache storage key
+    * @param value values to be added with their score
+    * @return number of inserted elements ignoring already existing. If the INCR option is specified, it returns 0
+    */
+  def setAdd( key: String, value: (Any, Double)* ): Future[ Long ]
+
+  /**
+    * Returns the sorted set cardinality (number of elements) of the sorted set stored at key.
+    *
+    * Time complexity: O(1)
+    *
+    * @param key cache storage key
+    * @return the cardinality (number of elements) of the sorted set, or 0 if key does not exist.
+    */
+  def setSize( key: String ): Future[ Long ]
+
+  /**
+    * Returns the specified range of elements in the sorted set stored at key. The elements are considered to be
+    * ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
+    *
+    * See ZREVRANGE when you need the elements ordered from highest to lowest score (and descending lexicographical
+    * order for elements with equal score).
+    *
+    * Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.
+    * They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last
+    * element of the sorted set, -2 the penultimate element and so on.
+    *
+    * start and stop are inclusive ranges, so for example ZRANGE myzset 0 1 will return both the first and the
+    * second element of the sorted set.
+    *
+    * Out of range indexes will not produce an error. If start is larger than the largest index in the sorted set,
+    * or start > stop, an empty list is returned. If stop is larger than the end of the sorted set Redis will treat
+    * it like it is the last element of the sorted set.
+    *
+    * Time complexity: O(log(N)+M) with N being the number of elements in the sorted set and M the number of
+    * elements returned.
+    *
+    * @param key   cache storage key
+    * @param start start index of the subset
+    * @param end   end index of the subset
+    * @tparam T expected type of the elements
+    * @return the subset
+    */
+  def setSlice[ T: ClassTag ]( key: String, start: Long, end: Long ): Future[ Set[ T ] ]
+
+  /**
+    * Returns the rank of member in the sorted set stored at key, with the scores ordered from low to high. The
+    * rank (or index) is 0-based, which means that the member with the lowest score has rank 0.
+    *
+    * Use ZREVRANK to get the rank of an element with the scores ordered from high to low.
+    *
+    * @param key   cache storage key
+    * @param value tested element
+    * @return index of the element if exists, None otherwise
+    */
+  def setRank( key: String, value: Any ): Future[ Option[ Long ] ]
+
+  /**
+    * Removes the specified members from the sorted set stored at key. Non existing members are ignored.
+    *
+    * An error is returned when key exists and does not hold a sorted set.
+    *
+    * Time complexity: O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.
+    *
+    * @param key   cache storage key
+    * @param value values to be removed
+    * @return total number of removed values, non existing are ignored
+    */
+  def setRemove( key: String, value: Any* ): Future[ Long ]
 }

--- a/src/main/scala/play/api/cache/redis/RedisSet.scala
+++ b/src/main/scala/play/api/cache/redis/RedisSet.scala
@@ -3,9 +3,8 @@ package play.api.cache.redis
 import scala.language.higherKinds
 
 /**
-  * Redis Sorted Sets are simply sets of objects, sorted by either their
-  * score or lexically. It is possible to add elements to a Redis Sorted
-  * Set by adding new elements into the collection.
+  * Redis Sets are simply unsorted sets of objects. It is possible to add
+  * elements to a Redis Set by adding new elements into the collection.
   *
   * <strong>This simplified wrapper implements only unordered Sets.</strong>
   *
@@ -15,21 +14,12 @@ import scala.language.higherKinds
 trait RedisSet[ Elem, Result[ _ ] ] extends RedisCollection[ Set[ Elem ] ] {
 
   /**
-    * <p>Adds all the specified members with the specified scores to the sorted set stored at key. It is possible to
-    * specify multiple score / member pairs. If a specified member is already a member of the sorted set, the score
-    * is updated and the element reinserted at the right position to ensure the correct ordering.</p>
+    * <p>Add the specified members to the set stored at key. Specified members that are already a member of this
+    * set are ignored. If key does not exist, a new set is created before adding the specified members.</p>
     *
-    * <p>If key does not exist, a new sorted set with the specified members as sole members is created, like if the
-    * sorted set was empty. If the key exists but does not hold a sorted set, an error is returned.</p>
-    *
-    * <p>The score values should be the string representation of a double precision floating point number.
-    * +inf and -inf values are valid values as well.</p>
-    *
-    * <p><strong>Note:</strong> This implements only lexicographical ordering to simplify use</p>
-    *
-    * <p><strong>Time complexity:</strong> O(log(N)) for each item added, where N is the number of elements in
-    * the sorted set.</p>
-    *
+    * @note An error is returned when the value stored at key is not a set.
+    * @note <strong>Time complexity:</strong>  O(1) for each element added, so O(N) to add N elements when the
+    *       command is called with multiple arguments.
     * @param element elements to be added
     * @return the set for chaining calls
     */
@@ -38,8 +28,7 @@ trait RedisSet[ Elem, Result[ _ ] ] extends RedisCollection[ Set[ Elem ] ] {
   /**
     * <p>Tests if the element is contained in the set. Returns true if exists, otherwise returns false</p>
     *
-    * <p><strong>Time complexity:</strong> O(log(N))</p>
-    *
+    * @note <strong>Time complexity:</strong> O(1)
     * @param element tested element
     * @return true if exists in the set, otherwise false
     */
@@ -49,8 +38,7 @@ trait RedisSet[ Elem, Result[ _ ] ] extends RedisCollection[ Set[ Elem ] ] {
     * <p>Removes the specified members from the sorted set stored at key. Non existing members are ignored.
     * An error is returned when key exists and does not hold a sorted set.</p>
     *
-    * <p><strong>Time complexity:</strong> O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.</p>
-    *
+    * @note <strong>Time complexity:</strong> O(N) where N is the number of members to be removed.
     * @param element elements to be removed
     * @return the set for chaining calls
     */
@@ -59,18 +47,13 @@ trait RedisSet[ Elem, Result[ _ ] ] extends RedisCollection[ Set[ Elem ] ] {
   /**
     * <p>Returns all elements in the set</p>
     *
-    * <p>Returns the specified range of elements in the sorted set stored at key. The elements are considered to
-    * be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.</p>
-    *
-    * <p><strong>Time complexity:</strong> O(log(N)+M) with N being the number of elements in the sorted set and M
-    * the number of elements returned.</p>
-    *
+    * @note <strong>Time complexity:</strong> O(N) where N is the set cardinality.
     * @return all elements in the set
     */
   def toSet: Result[ Set[ Elem ] ]
 
   /**
-    * <p>Returns the sorted set cardinality (number of elements) of the sorted set stored at key.</p>
+    * <p>Returns the set cardinality (number of elements) of the set stored at key.</p>
     *
     * <p><strong>Time complexity:</strong> O(1)</p>
     *

--- a/src/main/scala/play/api/cache/redis/RedisSet.scala
+++ b/src/main/scala/play/api/cache/redis/RedisSet.scala
@@ -1,0 +1,94 @@
+package play.api.cache.redis
+
+import scala.language.higherKinds
+
+/**
+  * Redis Sorted Sets are simply sets of objects, sorted by either their
+  * score or lexically. It is possible to add elements to a Redis Sorted
+  * Set by adding new elements into the collection.
+  *
+  * <strong>This simplified wrapper implements only unordered Sets.</strong>
+  *
+  * @tparam Elem Data type of the inserted element
+  * @author Karel Cemus
+  */
+trait RedisSet[ Elem, Result[ _ ] ] extends RedisCollection[ Set[ Elem ] ] {
+
+  /**
+    * <p>Adds all the specified members with the specified scores to the sorted set stored at key. It is possible to
+    * specify multiple score / member pairs. If a specified member is already a member of the sorted set, the score
+    * is updated and the element reinserted at the right position to ensure the correct ordering.</p>
+    *
+    * <p>If key does not exist, a new sorted set with the specified members as sole members is created, like if the
+    * sorted set was empty. If the key exists but does not hold a sorted set, an error is returned.</p>
+    *
+    * <p>The score values should be the string representation of a double precision floating point number.
+    * +inf and -inf values are valid values as well.</p>
+    *
+    * <p><strong>Note:</strong> This implements only lexicographical ordering to simplify use</p>
+    *
+    * <p><strong>Time complexity:</strong> O(log(N)) for each item added, where N is the number of elements in
+    * the sorted set.</p>
+    *
+    * @param element elements to be added
+    * @return the set for chaining calls
+    */
+  def add( element: Elem* ): Result[ This ]
+
+  /**
+    * <p>Tests if the element is contained in the set. Returns true if exists, otherwise returns false</p>
+    *
+    * <p><strong>Time complexity:</strong> O(log(N))</p>
+    *
+    * @param element tested element
+    * @return true if exists in the set, otherwise false
+    */
+  def contains( element: Elem ): Result[ Boolean ]
+
+  /**
+    * <p>Removes the specified members from the sorted set stored at key. Non existing members are ignored.
+    * An error is returned when key exists and does not hold a sorted set.</p>
+    *
+    * <p><strong>Time complexity:</strong> O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.</p>
+    *
+    * @param element elements to be removed
+    * @return the set for chaining calls
+    */
+  def remove( element: Elem* ): Result[ This ]
+
+  /**
+    * <p>Returns all elements in the set</p>
+    *
+    * <p>Returns the specified range of elements in the sorted set stored at key. The elements are considered to
+    * be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.</p>
+    *
+    * <p><strong>Time complexity:</strong> O(log(N)+M) with N being the number of elements in the sorted set and M
+    * the number of elements returned.</p>
+    *
+    * @return all elements in the set
+    */
+  def toSet: Result[ Set[ Elem ] ]
+
+  /**
+    * <p>Returns the sorted set cardinality (number of elements) of the sorted set stored at key.</p>
+    *
+    * <p><strong>Time complexity:</strong> O(1)</p>
+    *
+    * @return size of the set or 0 if does not exists
+    */
+  def size: Result[ Long ]
+
+  /**
+    * <p><strong>Time complexity:</strong> O(1)</p>
+    *
+    * @return returns true if the set is empty or key is not used
+    */
+  def isEmpty: Result[ Boolean ]
+
+  /**
+    * <p><strong>Time complexity:</strong> O(1)</p>
+    *
+    * @return returns true if the set exists and is not empty
+    */
+  def nonEmpty: Result[ Boolean ]
+}

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -75,4 +75,7 @@ private[ impl ] class RedisCache[ Result[ _ ] ]( redis: RedisConnector )( implic
 
   override def list[ T: ClassTag ]( key: String ): RedisList[ T, Result ] =
     new RedisListImpl( key, redis )
+
+  override def set[ T: ClassTag ]( key: String ): RedisSet[ T, Result ] =
+    new RedisSetImpl( key, redis )
 }

--- a/src/main/scala/play/api/cache/redis/impl/RedisSetImpl.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisSetImpl.scala
@@ -5,7 +5,7 @@ import scala.reflect.ClassTag
 
 import play.api.cache.redis._
 
-/** <p>Implementation of Sorted Set API using redis-server cache implementation.</p> */
+/** <p>Implementation of Set API using redis-server cache implementation.</p> */
 private[ impl ] class RedisSetImpl[ Elem: ClassTag, Result[ _ ] ]( key: String, redis: RedisConnector )( implicit builder: Builders.ResultBuilder[ Result ], policy: RecoveryPolicy ) extends RedisSet[ Elem, Result ] with Implicits {
 
   // implicit ask timeout and execution context
@@ -14,13 +14,13 @@ private[ impl ] class RedisSetImpl[ Elem: ClassTag, Result[ _ ] ]( key: String, 
   @inline
   private def This: This = this
 
-  def add( element: Elem* ) = redis.setAdd( key, element.map( _ -> 0D ): _* ).map( _ => This ).recoverWithDefault( This )
+  def add( elements: Elem* ) = redis.setAdd( key, elements: _* ).map( _ => This ).recoverWithDefault( This )
 
-  def contains( element: Elem ) = redis.setRank( key, element ).map( _.nonEmpty ).recoverWithDefault( false )
+  def contains( element: Elem ) = redis.setIsMember( key, element ).recoverWithDefault( false )
 
   def remove( element: Elem* ) = redis.setRemove( key, element: _* ).map( _ => This ).recoverWithDefault( This )
 
-  def toSet = redis.setSlice[ Elem ]( key, 0, -1 ).recoverWithDefault( Set.empty )
+  def toSet = redis.setMembers[ Elem ]( key ).recoverWithDefault( Set.empty )
 
   def size = redis.setSize( key ).recoverWithDefault( 0 )
 

--- a/src/main/scala/play/api/cache/redis/impl/RedisSetImpl.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisSetImpl.scala
@@ -1,0 +1,30 @@
+package play.api.cache.redis.impl
+
+import scala.language.{higherKinds, implicitConversions}
+import scala.reflect.ClassTag
+
+import play.api.cache.redis._
+
+/** <p>Implementation of Sorted Set API using redis-server cache implementation.</p> */
+private[ impl ] class RedisSetImpl[ Elem: ClassTag, Result[ _ ] ]( key: String, redis: RedisConnector )( implicit builder: Builders.ResultBuilder[ Result ], policy: RecoveryPolicy ) extends RedisSet[ Elem, Result ] with Implicits {
+
+  // implicit ask timeout and execution context
+  import redis.{context, timeout}
+
+  @inline
+  private def This: This = this
+
+  def add( element: Elem* ) = redis.setAdd( key, element.map( _ -> 0D ): _* ).map( _ => This ).recoverWithDefault( This )
+
+  def contains( element: Elem ) = redis.setRank( key, element ).map( _.nonEmpty ).recoverWithDefault( false )
+
+  def remove( element: Elem* ) = redis.setRemove( key, element: _* ).map( _ => This ).recoverWithDefault( This )
+
+  def toSet = redis.setSlice[ Elem ]( key, 0, -1 ).recoverWithDefault( Set.empty )
+
+  def size = redis.setSize( key ).recoverWithDefault( 0 )
+
+  def isEmpty = redis.setSize( key ).map( _ == 0 ).recoverWithDefault( true )
+
+  def nonEmpty = redis.setSize( key ).map( _ > 0 ).recoverWithDefault( false )
+}

--- a/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
+++ b/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
@@ -85,18 +85,18 @@ object FailingConnector extends RedisConnector with Synchronization {
   def listInsert( key: String, pivot: Any, value: Any ) =
     failKeyed( key, "LINSERT" )
 
-  def setAdd( key: String, value: (Any, Double)* ) =
-    failKeyed( key, "ZADD" )
+  def setAdd( key: String, value: Any* ) =
+    failKeyed( key, "SADD" )
 
   def setSize( key: String ) =
-    failKeyed( key, "ZCARD" )
+    failKeyed( key, "SCARD" )
 
-  def setSlice[ T: ClassTag ]( key: String, start: Long, end: Long ) =
-    failKeyed( key, "ZRANGE" )
+  def setMembers[ T: ClassTag ]( key: String ) =
+    failKeyed( key, "SMEMBERS" )
 
-  def setRank( key: String, value: Any ) =
-    failKeyed( key, "ZRANK" )
+  def setIsMember( key: String, value: Any ) =
+    failKeyed( key, "SISMEMBER" )
 
   def setRemove( key: String, value: Any* ) =
-    failKeyed( key, "ZREM" )
+    failKeyed( key, "SREM" )
 }

--- a/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
+++ b/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
@@ -84,4 +84,19 @@ object FailingConnector extends RedisConnector with Synchronization {
 
   def listInsert( key: String, pivot: Any, value: Any ) =
     failKeyed( key, "LINSERT" )
+
+  def setAdd( key: String, value: (Any, Double)* ) =
+    failKeyed( key, "ZADD" )
+
+  def setSize( key: String ) =
+    failKeyed( key, "ZCARD" )
+
+  def setSlice[ T: ClassTag ]( key: String, start: Long, end: Long ) =
+    failKeyed( key, "ZRANGE" )
+
+  def setRank( key: String, value: Any ) =
+    failKeyed( key, "ZRANK" )
+
+  def setRemove( key: String, value: Any* ) =
+    failKeyed( key, "ZREM" )
 }

--- a/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
@@ -316,37 +316,37 @@ class RedisConnectorSpec extends Specification with Redis {
 
     "set add" in {
       Cache.setSize( s"$prefix-test-set-add" ).sync must beEqualTo( 0 )
-      Cache.setAdd( s"$prefix-test-set-add", "A" -> 1, "B" -> 2 ).sync must beEqualTo( 2 )
+      Cache.setAdd( s"$prefix-test-set-add", "A", "B" ).sync must beEqualTo( 2 )
       Cache.setSize( s"$prefix-test-set-add" ).sync must beEqualTo( 2 )
-      Cache.setAdd( s"$prefix-test-set-add", "C" -> 2, "B" -> 3 ).sync must beEqualTo( 1 )
+      Cache.setAdd( s"$prefix-test-set-add", "C", "B" ).sync must beEqualTo( 1 )
       Cache.setSize( s"$prefix-test-set-add" ).sync must beEqualTo( 3 )
     }
 
     "set rank" in {
       Cache.setSize( s"$prefix-test-set-rank" ).sync must beEqualTo( 0 )
-      Cache.setAdd( s"$prefix-test-set-rank", "A" -> 1, "B" -> 2 ).sync must beEqualTo( 2 )
+      Cache.setAdd( s"$prefix-test-set-rank", "A", "B" ).sync must beEqualTo( 2 )
       Cache.setSize( s"$prefix-test-set-rank" ).sync must beEqualTo( 2 )
 
-      Cache.setRank( s"$prefix-test-set-rank", "A" ).sync must beSome( 0 )
-      Cache.setRank( s"$prefix-test-set-rank", "B" ).sync must beSome( 1 )
-      Cache.setRank( s"$prefix-test-set-rank", "C" ).sync must beNone
+      Cache.setIsMember( s"$prefix-test-set-rank", "A" ).sync must beTrue
+      Cache.setIsMember( s"$prefix-test-set-rank", "B" ).sync must beTrue
+      Cache.setIsMember( s"$prefix-test-set-rank", "C" ).sync must beFalse
 
-      Cache.setAdd( s"$prefix-test-set-rank", "C" -> 2, "B" -> 3 ).sync must beEqualTo( 1 )
+      Cache.setAdd( s"$prefix-test-set-rank", "C", "B" ).sync must beEqualTo( 1 )
 
-      Cache.setRank( s"$prefix-test-set-rank", "A" ).sync must beSome( 0 )
-      Cache.setRank( s"$prefix-test-set-rank", "B" ).sync must beSome( 2 )
-      Cache.setRank( s"$prefix-test-set-rank", "C" ).sync must beSome( 1 )
+      Cache.setIsMember( s"$prefix-test-set-rank", "A" ).sync must beTrue
+      Cache.setIsMember( s"$prefix-test-set-rank", "B" ).sync must beTrue
+      Cache.setIsMember( s"$prefix-test-set-rank", "C" ).sync must beTrue
     }
 
     "set size" in {
       Cache.setSize( s"$prefix-test-set-size" ).sync must beEqualTo( 0 )
-      Cache.setAdd( s"$prefix-test-set-size", "A" -> 1, "B" -> 2 ).sync must beEqualTo( 2 )
+      Cache.setAdd( s"$prefix-test-set-size", "A", "B" ).sync must beEqualTo( 2 )
       Cache.setSize( s"$prefix-test-set-size" ).sync must beEqualTo( 2 )
     }
 
     "set rem" in {
       Cache.setSize( s"$prefix-test-set-rem" ).sync must beEqualTo( 0 )
-      Cache.setAdd( s"$prefix-test-set-rem", "A" -> 1, "B" -> 2, "C" -> 3 ).sync must beEqualTo( 3 )
+      Cache.setAdd( s"$prefix-test-set-rem", "A", "B", "C" ).sync must beEqualTo( 3 )
       Cache.setSize( s"$prefix-test-set-rem" ).sync must beEqualTo( 3 )
 
       Cache.setRemove( s"$prefix-test-set-rem", "A" ).sync must beEqualTo( 1 )
@@ -357,12 +357,10 @@ class RedisConnectorSpec extends Specification with Redis {
 
     "set slice" in {
       Cache.setSize( s"$prefix-test-set-slice" ).sync must beEqualTo( 0 )
-      Cache.setAdd( s"$prefix-test-set-slice", "A" -> 1, "B" -> 2, "C" -> 3 ).sync must beEqualTo( 3 )
+      Cache.setAdd( s"$prefix-test-set-slice", "A", "B", "C" ).sync must beEqualTo( 3 )
       Cache.setSize( s"$prefix-test-set-slice" ).sync must beEqualTo( 3 )
 
-      Cache.setSlice[ String ]( s"$prefix-test-set-slice", 0, 0 ).sync must beEqualTo( Set( "A" ) )
-      Cache.setSlice[ String ]( s"$prefix-test-set-slice", 0, -1 ).sync must beEqualTo( Set( "A", "B", "C" ) )
-      Cache.setSlice[ String ]( s"$prefix-test-set-slice", 1, 2 ).sync must beEqualTo( Set( "B", "C" ) )
+      Cache.setMembers[ String ]( s"$prefix-test-set-slice" ).sync must beEqualTo( Set( "A", "B", "C" ) )
 
       Cache.setSize( s"$prefix-test-set-slice" ).sync must beEqualTo( 3 )
     }

--- a/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
@@ -313,6 +313,59 @@ class RedisConnectorSpec extends Specification with Redis {
       Cache.set( s"$prefix-test-list-insert-2", "string value" ).sync
       Cache.listInsert( s"$prefix-test-list-insert-2", "C", "B" ).sync must throwA[ IllegalArgumentException ]
     }
+
+    "set add" in {
+      Cache.setSize( s"$prefix-test-set-add" ).sync must beEqualTo( 0 )
+      Cache.setAdd( s"$prefix-test-set-add", "A" -> 1, "B" -> 2 ).sync must beEqualTo( 2 )
+      Cache.setSize( s"$prefix-test-set-add" ).sync must beEqualTo( 2 )
+      Cache.setAdd( s"$prefix-test-set-add", "C" -> 2, "B" -> 3 ).sync must beEqualTo( 1 )
+      Cache.setSize( s"$prefix-test-set-add" ).sync must beEqualTo( 3 )
+    }
+
+    "set rank" in {
+      Cache.setSize( s"$prefix-test-set-rank" ).sync must beEqualTo( 0 )
+      Cache.setAdd( s"$prefix-test-set-rank", "A" -> 1, "B" -> 2 ).sync must beEqualTo( 2 )
+      Cache.setSize( s"$prefix-test-set-rank" ).sync must beEqualTo( 2 )
+
+      Cache.setRank( s"$prefix-test-set-rank", "A" ).sync must beSome( 0 )
+      Cache.setRank( s"$prefix-test-set-rank", "B" ).sync must beSome( 1 )
+      Cache.setRank( s"$prefix-test-set-rank", "C" ).sync must beNone
+
+      Cache.setAdd( s"$prefix-test-set-rank", "C" -> 2, "B" -> 3 ).sync must beEqualTo( 1 )
+
+      Cache.setRank( s"$prefix-test-set-rank", "A" ).sync must beSome( 0 )
+      Cache.setRank( s"$prefix-test-set-rank", "B" ).sync must beSome( 2 )
+      Cache.setRank( s"$prefix-test-set-rank", "C" ).sync must beSome( 1 )
+    }
+
+    "set size" in {
+      Cache.setSize( s"$prefix-test-set-size" ).sync must beEqualTo( 0 )
+      Cache.setAdd( s"$prefix-test-set-size", "A" -> 1, "B" -> 2 ).sync must beEqualTo( 2 )
+      Cache.setSize( s"$prefix-test-set-size" ).sync must beEqualTo( 2 )
+    }
+
+    "set rem" in {
+      Cache.setSize( s"$prefix-test-set-rem" ).sync must beEqualTo( 0 )
+      Cache.setAdd( s"$prefix-test-set-rem", "A" -> 1, "B" -> 2, "C" -> 3 ).sync must beEqualTo( 3 )
+      Cache.setSize( s"$prefix-test-set-rem" ).sync must beEqualTo( 3 )
+
+      Cache.setRemove( s"$prefix-test-set-rem", "A" ).sync must beEqualTo( 1 )
+      Cache.setSize( s"$prefix-test-set-rem" ).sync must beEqualTo( 2 )
+      Cache.setRemove( s"$prefix-test-set-rem", "B", "C", "D" ).sync must beEqualTo( 2 )
+      Cache.setSize( s"$prefix-test-set-rem" ).sync must beEqualTo( 0 )
+    }
+
+    "set slice" in {
+      Cache.setSize( s"$prefix-test-set-slice" ).sync must beEqualTo( 0 )
+      Cache.setAdd( s"$prefix-test-set-slice", "A" -> 1, "B" -> 2, "C" -> 3 ).sync must beEqualTo( 3 )
+      Cache.setSize( s"$prefix-test-set-slice" ).sync must beEqualTo( 3 )
+
+      Cache.setSlice[ String ]( s"$prefix-test-set-slice", 0, 0 ).sync must beEqualTo( Set( "A" ) )
+      Cache.setSlice[ String ]( s"$prefix-test-set-slice", 0, -1 ).sync must beEqualTo( Set( "A", "B", "C" ) )
+      Cache.setSlice[ String ]( s"$prefix-test-set-slice", 1, 2 ).sync must beEqualTo( Set( "B", "C" ) )
+
+      Cache.setSize( s"$prefix-test-set-slice" ).sync must beEqualTo( 3 )
+    }
   }
 
 }

--- a/src/test/scala/play/api/cache/redis/impl/RedisListSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/RedisListSpec.scala
@@ -31,7 +31,7 @@ class RedisListSpec extends Specification with Redis {
 
     def objects( key: String ) = list[ SimpleObject ]( key )
 
-    "AsynchronousRedisList" should {
+    "SynchronousRedisList" should {
 
       import expectation._
 

--- a/src/test/scala/play/api/cache/redis/impl/RedisSetSpecs.scala
+++ b/src/test/scala/play/api/cache/redis/impl/RedisSetSpecs.scala
@@ -1,0 +1,125 @@
+package play.api.cache.redis.impl
+
+import scala.reflect.ClassTag
+
+import play.api.cache.redis._
+
+import org.specs2.mutable.Specification
+
+/**
+  * <p>Test of cache to be sure that keys are differentiated, expires etc.</p>
+  */
+class RedisSetSpecs extends Specification with Redis {
+  outer =>
+
+  private type Cache = RedisCache[ SynchronousResult ]
+
+  private val workingConnector = injector.instanceOf[ RedisConnector ]
+
+  // test proper implementation, no fails
+  new RedisSetSuite( "implement", "redis-cache-implements", new RedisCache( workingConnector )( Builders.SynchronousBuilder, FailThrough ), AlwaysSuccess )
+
+  //  new RedisSetSuite( "recover from", "redis-cache-recovery", new RedisCache( FailingConnector )( Builders.SynchronousBuilder, RecoverWithDefault ), AlwaysDefault )
+
+  //  new RedisSetSuite( "fail on", "redis-cache-fail", new RedisCache( FailingConnector )( Builders.SynchronousBuilder, FailThrough ), AlwaysException )
+
+  class RedisSetSuite( suiteName: String, prefix: String, cache: Cache, expectation: Expectation ) {
+
+    def set[ T: ClassTag ]( key: String ) = cache.set[ T ]( key )
+
+    implicit class Key( val key: String )
+
+    def strings( implicit theKey: Key ) = set[ String ]( theKey.key )
+
+    def objects( implicit theKey: Key ) = set[ SimpleObject ]( theKey.key )
+
+    "SynchronousRedisSet" should {
+
+      import expectation._
+
+      suiteName >> {
+
+        "add into the set" in {
+          implicit val key: Key = s"$prefix-set-add"
+
+          strings.size must expectsNow( 0 )
+          strings.isEmpty must expectsNow( beTrue )
+          strings.nonEmpty must expectsNow( beFalse )
+
+          strings.add( "A", "B", "D" ).add( "C" ).add( "A" ).size must expectsNow( 4, 0 )
+          strings.isEmpty must expectsNow( beFalse, beTrue )
+          strings.nonEmpty must expectsNow( beTrue, beFalse )
+
+          strings.toSet must expectsNow( Set( "A", "B", "C", "D" ), Set.empty )
+          strings.contains( "A" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "B" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "C" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "D" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "E" ) must expectsNow( beFalse, beFalse )
+        }
+
+        "remove from the set" in {
+          implicit val key: Key = s"$prefix-set-remove"
+
+          strings.size must expectsNow( 0 )
+          strings.add( "A", "B", "D" ).size must expectsNow( 3, 0 )
+
+          strings.contains( "A" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "B" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "C" ) must expectsNow( beFalse, beFalse )
+          strings.contains( "D" ) must expectsNow( beTrue, beFalse )
+
+          strings.remove( "A" ).size must expectsNow( 2, 0 )
+          strings.contains( "A" ) must expectsNow( beFalse, beFalse )
+          strings.contains( "B" ) must expectsNow( beTrue, beFalse )
+          strings.contains( "C" ) must expectsNow( beFalse, beFalse )
+          strings.contains( "D" ) must expectsNow( beTrue, beFalse )
+
+          strings.remove( "B", "C", "D" ).size must expectsNow( 0, 0 )
+          strings.contains( "A" ) must expectsNow( beFalse, beFalse )
+          strings.contains( "B" ) must expectsNow( beFalse, beFalse )
+          strings.contains( "C" ) must expectsNow( beFalse, beFalse )
+          strings.contains( "D" ) must expectsNow( beFalse, beFalse )
+        }
+
+        "working with the set at non-set key" in {
+          implicit val key: Key = s"$prefix-set-invalid"
+
+          cache.set( key.key, "invalid" ) must expectsNow( beUnit )
+          strings.add( "A" ) must expectsNow( throwA[ IllegalArgumentException ], beAnInstanceOf[ RedisList[ String, AsynchronousResult ] ] )
+        }
+
+        "objects in the set" in {
+          implicit val key: Key = s"$prefix-set-objects"
+
+          def A = SimpleObject( "A", 1 )
+          def B = SimpleObject( "B", 2 )
+          def C = SimpleObject( "C", 3 )
+          def D = SimpleObject( "D", 4 )
+          def E = SimpleObject( "E", 5 )
+
+          objects.size must expectsNow( 0 )
+          objects.add( A, B, D ).add( A ).size must expectsNow( 3, 0 )
+
+          objects.contains( A ) must expectsNow( beTrue, beFalse )
+          objects.contains( B ) must expectsNow( beTrue, beFalse )
+          objects.contains( C ) must expectsNow( beFalse, beFalse )
+          objects.contains( D ) must expectsNow( beTrue, beFalse )
+
+          objects.remove( A ).size must expectsNow( 2, 0 )
+          objects.contains( A ) must expectsNow( beFalse, beFalse )
+          objects.contains( B ) must expectsNow( beTrue, beFalse )
+          objects.contains( C ) must expectsNow( beFalse, beFalse )
+          objects.contains( D ) must expectsNow( beTrue, beFalse )
+
+          objects.remove( B, C, D ).size must expectsNow( 0, 0 )
+          objects.contains( A ) must expectsNow( beFalse, beFalse )
+          objects.contains( B ) must expectsNow( beFalse, beFalse )
+          objects.contains( C ) must expectsNow( beFalse, beFalse )
+          objects.contains( D ) must expectsNow( beFalse, beFalse )
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/scala/play/api/cache/redis/impl/package.scala
+++ b/src/test/scala/play/api/cache/redis/impl/package.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.language.higherKinds
+import scala.language.{higherKinds, implicitConversions}
 
 import play.api.cache.redis.exception.ExecutionFailedException
 
@@ -78,6 +78,7 @@ package object impl extends LowPriorityImplicits {
     } )
   }
 
+  implicit def expected2matcher[T]( expected: => T ): Matcher[ T ] = Matchers.beEqualTo(expected)
 }
 
 trait LowPriorityImplicits {


### PR DESCRIPTION
Resolves #49 

Implements Redis data type `Set` as a simple Scala wrapper. See specifications or Redis documentation for more details.