### PR TITLE
MGET, MSET and MSETNX commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ class MyController @Inject() ( cache: CacheApi ) {
   cache.get[ Double ]( "key" )
   // returns Option[ MyCaseClass ]
   cache.get[ MyCaseClass ]( "object" )
+  
+  // set multiple values at once
+  cache.setAll( "key" -> 1.23, "key2" -> 5, "key3" -> 6 )
+  // set only when all keys are unused
+  cache.setAllIfNotExist( "key" -> 1.23, "key2" -> 5, "key3" -> 6 )
+  // get multiple keys at once, returns a list of options
+  cache.getAll[ Double ]( "key", "key2", "key3", "key6" )
 
   // returns T where T is Double. If the value is not in the cache
   // the computed result is saved
@@ -395,6 +402,8 @@ Nevertheless, this module **replaces** the EHCache and it is not intended to use
 ### [:link: 1.3.2](https://github.com/KarelCemus/play-redis/tree/1.3.2)
 
 Implemented `RedisCacheComponents` to support [compile-time DI](#using-with-compile-time-di)
+
+Implemented [MGET](https://redis.io/commands/mget), [MSET](https://redis.io/commands/mset) and [MSETNX](https://redis.io/commands/msetnx) redis commands.
 
 ### [:link: 1.3.1](https://github.com/KarelCemus/play-redis/tree/1.3.1)
 

--- a/src/main/scala/play/api/cache/redis/CacheApi.scala
+++ b/src/main/scala/play/api/cache/redis/CacheApi.scala
@@ -178,6 +178,20 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     */
   def decrement( key: String, by: Long = 1 ): Result[ Long ]
 
+  /** Retrieve the values of all specified keys from the cache.
+    *
+    * @param key cache storage keys
+    * @return stored record, Some if exists, otherwise None
+    */
+  def mGet[ T: ClassTag ](key: String* ): Result[ List[Option[ T] ] ]
+
+  /** Sets the given keys to their respective values for eternity.
+    *
+    * @param keyValues  cache storage key-value pairs to store
+    * @return promise
+    */
+  def mSet(keyValues: Map[String, Any]): Result[ Unit ]
+
   /**
     * Scala wrapper around Redis list-related commands. This simplifies use of the lists.
     *

--- a/src/main/scala/play/api/cache/redis/CacheApi.scala
+++ b/src/main/scala/play/api/cache/redis/CacheApi.scala
@@ -22,6 +22,13 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     */
   def get[ T: ClassTag ]( key: String ): Result[ Option[ T ] ]
 
+  /** Retrieve the values of all specified keys from the cache.
+    *
+    * @param key cache storage keys
+    * @return stored record, Some if exists, otherwise None
+    */
+  def getAll[ T: ClassTag ]( key: String* ): Result[ List[ Option[ T ] ] ]
+
   /** Retrieve a value from the cache. If is missing, set default value with
     * given expiration and return the value.
     *
@@ -83,6 +90,25 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     * @return true if value was set, false if was ignored because it existed before
     */
   def setIfNotExists( key: String, value: Any, expiration: Duration = Duration.Inf ): Result[ Boolean ]
+
+  /** Sets the given keys to their respective values for eternity. If any value is null,
+    * the particular key is excluded from the operation and removed from cache instead.
+    * The operation is atomic when there are no nulls. It replaces existing values.
+    *
+    * @param keyValues cache storage key-value pairs to store
+    * @return promise
+    */
+  def setAll( keyValues: (String, Any)* ): Result[ Unit ]
+
+  /** Sets the given keys to their respective values for eternity. It sets all values if none of them
+    * exist, if at least a single of them exists, it does not set any value, thus it is either all or none.
+    * If any value is null, the particular key is excluded from the operation and removed from cache instead.
+    * The operation is atomic when there are no nulls.
+    *
+    * @param keyValues cache storage key-value pairs to store
+    * @return true if value was set, false if any value already existed before
+    */
+  def setAllIfNotExist( keyValues: (String, Any)* ): Result[ Boolean ]
 
   /** If key already exists and is a string, this command appends the value at the end of
     * the string. If key does not exist it is created and set as an empty string, so APPEND
@@ -177,20 +203,6 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     * @since 1.3.0
     */
   def decrement( key: String, by: Long = 1 ): Result[ Long ]
-
-  /** Retrieve the values of all specified keys from the cache.
-    *
-    * @param key cache storage keys
-    * @return stored record, Some if exists, otherwise None
-    */
-  def mGet[ T: ClassTag ](key: String* ): Result[ List[Option[ T] ] ]
-
-  /** Sets the given keys to their respective values for eternity.
-    *
-    * @param keyValues  cache storage key-value pairs to store
-    * @return promise
-    */
-  def mSet(keyValues: Map[String, Any]): Result[ Unit ]
 
   /**
     * Scala wrapper around Redis list-related commands. This simplifies use of the lists.

--- a/src/main/scala/play/api/cache/redis/connector/RedisConnector.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisConnector.scala
@@ -92,6 +92,20 @@ private[ redis ] trait CoreCommands {
     */
   def increment( key: String, by: Long ): Future[ Long ]
 
+  /** Retrieve a values from the cache.
+    *
+    * @param keys cache storage key
+    * @return stored record, Some if exists, otherwise None
+    */
+  def mGet[ T: ClassTag ](keys: String* ): Future[ List[ Option[T] ] ]
+
+  /** Set a value into the cache. Expiration time in seconds for eternity.
+    *
+    * @param keyValues  cache storage key-value pairs to store
+    * @return promise
+    */
+  def mSet(keyValues: Map[String, Any]): Future[ Unit ]
+
   /** If key already exists and is a string, this command appends the value at the
     * end of the string. If key does not exist it is created and set as an empty string,
     * so APPEND will be similar to SET in this special case.

--- a/src/main/scala/play/api/cache/redis/connector/RedisConnector.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisConnector.scala
@@ -23,6 +23,13 @@ private[ redis ] trait CoreCommands {
     */
   def get[ T: ClassTag ]( key: String ): Future[ Option[ T ] ]
 
+  /** Retrieve a values from the cache.
+    *
+    * @param keys cache storage key
+    * @return stored record, Some if exists, otherwise None
+    */
+  def mGet[ T: ClassTag ]( keys: String* ): Future[ List[ Option[ T ] ] ]
+
   /** Determines whether value exists in cache.
     *
     * @param key cache storage key
@@ -55,6 +62,21 @@ private[ redis ] trait CoreCommands {
     * @return true if set was successful, false if key was already defined
     */
   def setIfNotExists( key: String, value: Any ): Future[ Boolean ]
+
+  /** Set a value into the cache. Expiration time is the eternity.
+    *
+    * @param keyValues cache storage key-value pairs to store
+    * @return promise
+    */
+  def mSet( keyValues: (String, Any)* ): Future[ Unit ]
+
+  /** Set a value into the cache. Expiration time is the eternity.
+    * It either set all values or it sets none if any of them already exists.
+    *
+    * @param keyValues cache storage key-value pairs to store
+    * @return promise
+    */
+  def mSetIfNotExist( keyValues: (String, Any)* ): Future[ Boolean ]
 
   /** refreshes expiration time on a given key, useful, e.g., when we want to refresh session duration
     *
@@ -91,20 +113,6 @@ private[ redis ] trait CoreCommands {
     * @return the value after the increment
     */
   def increment( key: String, by: Long ): Future[ Long ]
-
-  /** Retrieve a values from the cache.
-    *
-    * @param keys cache storage key
-    * @return stored record, Some if exists, otherwise None
-    */
-  def mGet[ T: ClassTag ](keys: String* ): Future[ List[ Option[T] ] ]
-
-  /** Set a value into the cache. Expiration time in seconds for eternity.
-    *
-    * @param keyValues  cache storage key-value pairs to store
-    * @return promise
-    */
-  def mSet(keyValues: Map[String, Any]): Future[ Unit ]
 
   /** If key already exists and is a string, this command appends the value at the
     * end of the string. If key does not exist it is created and set as an empty string,

--- a/src/main/scala/play/api/cache/redis/connector/RedisConnectorImpl.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisConnectorImpl.scala
@@ -5,11 +5,12 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
+
 import play.api.Logger
 import play.api.cache.redis._
 import play.api.inject.ApplicationLifecycle
+
 import akka.actor.ActorSystem
-import akka.actor.Status.Success
 import scredis._
 
 /**
@@ -53,6 +54,19 @@ private[ connector ] class RedisConnectorImpl @Inject()( serializer: AkkaSeriali
         None
     }
 
+  def mGet[ T: ClassTag ]( keys: String* ): Future[ List[ Option[ T ] ] ] =
+    redis.mGet[ String ]( keys: _* ) executing "MGET" withParameters keys.mkString( " " ) expects {
+      // list is always returned
+      case list => keys.zip( list ).map {
+        case (key, Some( response: String )) =>
+          log.trace( s"Hit on key '$key'." )
+          Some( decode[ T ]( key, response ) )
+        case (key, None) =>
+          log.debug( s"Miss on key '$key'." )
+          None
+      }.toList
+    }
+
   /** decodes the object, reports an exception if fails */
   private def decode[ T: ClassTag ]( key: String, encoded: String ): T =
     serializer.decode[ T ]( encoded ).recover {
@@ -90,6 +104,34 @@ private[ connector ] class RedisConnectorImpl @Inject()( serializer: AkkaSeriali
     redis.setNX( key, encode( key, value ) ) executing "SETNX" withParameters s"$key ${ encode( key, value ) }" expects {
       case false => log.debug( s"Set if not exists on key '$key' ignored. Value already exists." ); false
       case true => log.debug( s"Set if not exists on key '$key' succeeded." ); true
+    }
+
+  def mSet( keyValues: (String, Any)* ): Future[ Unit ] = mSetUsing( mSetEternally, (), keyValues: _* )
+
+  def mSetIfNotExist( keyValues: (String, Any)* ): Future[ Boolean ] = mSetUsing( mSetEternallyIfNotExist, true, keyValues: _* )
+
+  /** eternally stores or removes all given values, using the given mSet implementation */
+  private def mSetUsing[ T ]( f: Seq[ (String, String) ] => Future[ T ], default: T, keyValues: (String, Any)* ): Future[ T ] = {
+    val (toBeRemoved, toBeSet) = keyValues.partition( _.isNull )
+    // remove all keys to be removed
+    val toBeRemovedFuture = if ( toBeRemoved.isEmpty ) Future.successful( () ) else remove( toBeRemoved.map( _.key ): _* )
+    // set all keys to be set
+    val toBeSetFuture = if ( toBeSet.isEmpty ) Future.successful( default ) else f( toBeSet.map( tuple => tuple.key -> encode( tuple.key, tuple.value ) ) )
+    // combine futures ignoring the result of removal
+    toBeRemovedFuture.flatMap( _ => toBeSetFuture )
+  }
+
+  /** eternally stores already encoded values into the storage */
+  private def mSetEternally( keyValues: (String, String)* ): Future[ Unit ] =
+    redis.mSet( keyValues.toMap ) executing "MSET" withParameters keyValues.map( _.asString ).mkString( " " ) expects {
+      case _ => log.debug( s"Set on keys ${ keyValues.map( _.key ) } for infinite seconds." )
+    }
+
+  /** eternally stores already encoded values into the storage */
+  private def mSetEternallyIfNotExist( keyValues: (String, String)* ): Future[ Boolean ] =
+    redis.mSetNX( keyValues.toMap ) executing "MSETNX" withParameters keyValues.map( _.asString ).mkString( " " ) expects {
+      case true => log.debug( s"Set if not exists on keys ${ keyValues.map( _.key ) mkString " " } succeeded." ); true
+      case false => log.debug( s"Set if not exists on keys ${ keyValues.map( _.key ) mkString " " } ignored. Some value already exists." ); false
     }
 
   def expire( key: String, expiration: Duration ): Future[ Unit ] =
@@ -134,40 +176,6 @@ private[ connector ] class RedisConnectorImpl @Inject()( serializer: AkkaSeriali
   def increment( key: String, by: Long ): Future[ Long ] =
     redis.incrBy( key, by ) executing "INCRBY" withParameters s"$key, $by" expects {
       case value => log.debug( s"The value at key '$key' was incremented by $by to $value." ); value
-    }
-
-  def mGet[ T: ClassTag ](keys: String* ): Future[ List[ Option[T] ] ] =
-    redis.mGet[String](keys: _*) executing "MGET" withParameters keys.mkString(" ") expects {
-      case list => // list is always returned
-        keys
-          .zip(list)
-          .map{
-            case (key, Some( response: String )) =>
-              log.trace( s"Hit on key '$key'." )
-              Some( decode[ T ]( key, response ) )
-            case (key, None) =>
-              log.debug( s"Miss on key '$key'." )
-              None
-          }
-          .toList
-    }
-
-  def mSet(keyValues: Map[String, Any]): Future[ Unit ] = {
-    keyValues
-      .filter{case (key,value) => value == null }
-      .foreach{case (key,value) =>  remove(key)}
-
-
-    mSetEternally( keyValues
-      .filter{case (key,value) => value != null }
-      .map{case (key,value) => (key, encode(key,value)) }
-    )
-  }
-
-  /** eternally stores already encoded value into the storage */
-  private def mSetEternally( keyValues: Map[String, String] ): Future[ Unit ] =
-    redis.mSet( keyValues ) executing "MSET" withParameters s"$keyValues" expects {
-      case _ => log.debug( s"Set on key '$keyValues' for infinite seconds." )
     }
 
   def append( key: String, value: String ): Future[ Long ] =

--- a/src/main/scala/play/api/cache/redis/connector/package.scala
+++ b/src/main/scala/play/api/cache/redis/connector/package.scala
@@ -9,4 +9,11 @@ import scala.language.implicitConversions
 package object connector {
 
   implicit def future2expected[ T ]( future: Future[ T ] ): ExpectedFutureBuilder[ T ] = new ExpectedFutureBuilder[ T ]( future )
+
+  implicit class TupleHelper[ +A, +B ]( tuple: (A, B) ) {
+    @inline def key: A = tuple._1
+    @inline def value: B = tuple._2
+    @inline def asString = s"$key $value"
+    @inline def isNull = value == null
+  }
 }

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -73,6 +73,12 @@ private[ impl ] class RedisCache[ Result[ _ ] ]( redis: RedisConnector )( implic
   override def decrement( key: String, by: Long ) =
     increment( key, -by )
 
+  override def mGet[ T: ClassTag ](keys: String* ): Result[ List[ Option[T] ] ] =
+    redis.mGet[T](keys: _*).recoverWithDefault( List() )
+
+  override def mSet(keyValues: Map[String, Any]): Result[ Unit ] =
+    redis.mSet(keyValues).recoverWithDefault( None )
+
   override def list[ T: ClassTag ]( key: String ): RedisList[ T, Result ] =
     new RedisListImpl( key, redis )
 

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -16,6 +16,9 @@ private[ impl ] class RedisCache[ Result[ _ ] ]( redis: RedisConnector )( implic
   override def get[ T: ClassTag ]( key: String ) =
     redis.get[ T ]( key ).recoverWithDefault( None )
 
+  override def getAll[ T: ClassTag ]( keys: String* ): Result[ List[ Option[ T ] ] ] =
+    redis.mGet[ T ]( keys: _* ).recoverWithDefault( keys.toList.map( _ => None ) )
+
   override def set( key: String, value: Any, expiration: Duration ) =
     redis.set( key, value, expiration ).recoverWithUnit
 
@@ -24,6 +27,12 @@ private[ impl ] class RedisCache[ Result[ _ ] ]( redis: RedisConnector )( implic
       if ( result && expiration.isFinite( ) ) redis.expire( key, expiration )
       result
     }.recoverWithDefault( true )
+
+  override def setAll( keyValues: (String, Any)* ): Result[ Unit ] =
+    redis.mSet( keyValues: _* ).recoverWithDefault( None )
+
+  override def setAllIfNotExist( keyValues: (String, Any)* ): Result[ Boolean ] =
+    redis.mSetIfNotExist( keyValues: _* ).recoverWithDefault( true )
 
   override def append( key: String, value: String, expiration: Duration ): Result[ Unit ] =
     redis.append( key, value ).map[ Unit ] { result =>
@@ -72,12 +81,6 @@ private[ impl ] class RedisCache[ Result[ _ ] ]( redis: RedisConnector )( implic
 
   override def decrement( key: String, by: Long ) =
     increment( key, -by )
-
-  override def mGet[ T: ClassTag ](keys: String* ): Result[ List[ Option[T] ] ] =
-    redis.mGet[T](keys: _*).recoverWithDefault( List() )
-
-  override def mSet(keyValues: Map[String, Any]): Result[ Unit ] =
-    redis.mSet(keyValues).recoverWithDefault( None )
 
   override def list[ T: ClassTag ]( key: String ): RedisList[ T, Result ] =
     new RedisListImpl( key, redis )

--- a/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
+++ b/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
@@ -30,8 +30,17 @@ object FailingConnector extends RedisConnector with Synchronization {
   def setIfNotExists( key: String, value: Any ): Future[ Boolean ] =
     failKeyed( key, "SETNX" )
 
+  def mSet( keyValues: (String, Any)* ): Future[ Unit ] =
+    failKeyed( keyValues.map( _._1 ).mkString( " " ), "MSET" )
+
+  def mSetIfNotExist( keyValues: (String, Any)* ): Future[ Boolean ] =
+    failKeyed( keyValues.map( _._1 ).mkString( " " ), "MSETNX" )
+
   def get[ T: ClassTag ]( key: String ): Future[ Option[ T ] ] =
     failKeyed( key, "GET" )
+
+  def mGet[ T: ClassTag ]( keys: String* ): Future[ List[ Option[ T ] ] ] =
+    failKeyed( keys.mkString( " " ), "MGET" )
 
   def expire( key: String, expiration: Duration ): Future[ Unit ] =
     failKeyed( key, "EXPIRE" )
@@ -53,13 +62,6 @@ object FailingConnector extends RedisConnector with Synchronization {
 
   def increment( key: String, by: Long ): Future[ Long ] =
     failKeyed( key, "INCR" )
-
-
-  def mGet[ T: ClassTag ](keys: String* ): Future[ List[ Option[T] ] ] =
-    failKeyed( keys.mkString(" "), "MGET" )
-
-  def mSet(keyValues: Map[String, Any]): Future[ Unit ]=
-    failKeyed( keyValues.map{case (key,value) => s"""$key "$value""""}.mkString(" "), "MSET" )
 
   def append( key: String, value: String ): Future[ Long ] =
     failKeyed( key, "APPEND" )

--- a/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
+++ b/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
@@ -54,6 +54,13 @@ object FailingConnector extends RedisConnector with Synchronization {
   def increment( key: String, by: Long ): Future[ Long ] =
     failKeyed( key, "INCR" )
 
+
+  def mGet[ T: ClassTag ](keys: String* ): Future[ List[ Option[T] ] ] =
+    failKeyed( keys.mkString(" "), "MGET" )
+
+  def mSet(keyValues: Map[String, Any]): Future[ Unit ]=
+    failKeyed( keyValues.map{case (key,value) => s"""$key "$value""""}.mkString(" "), "MSET" )
+
   def append( key: String, value: String ): Future[ Long ] =
     failKeyed( key, "APPEND" )
 

--- a/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
@@ -3,8 +3,10 @@ package play.api.cache.redis.connector
 import java.util.Date
 
 import scala.concurrent.duration._
+
 import play.api.cache.redis._
 import play.api.cache.redis.exception.ExecutionFailedException
+
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 
@@ -31,11 +33,6 @@ class RedisConnectorSpec extends Specification with Redis {
       Cache.get[ String ]( s"$prefix-test-2" ) must beSome( "value" )
     }
 
-    "hit after mset" in {
-      Cache.mSet(Map(s"$prefix-test-2-1" -> "value-1", s"$prefix-test-2-2" -> "value-2") ).sync
-      Cache.mGet[ String ]( s"$prefix-test-2-1", s"$prefix-test-2-2" ).sync must beEqualTo(List(Some("value-1"), Some("value-2")))
-    }
-
     "ignore set if not exists when already defined" in {
       Cache.set( s"$prefix-test-if-not-exists-when-exists", "previous" ).sync
       Cache.setIfNotExists( s"$prefix-test-if-not-exists-when-exists", "value" ) must beFalse
@@ -47,6 +44,17 @@ class RedisConnectorSpec extends Specification with Redis {
       Cache.setIfNotExists( s"$prefix-test-if-not-exists", "value" ) must beTrue
       Cache.get[ String ]( s"$prefix-test-if-not-exists" ) must beSome[ Any ]
       Cache.get[ String ]( s"$prefix-test-if-not-exists" ) must beSome( "value" )
+    }
+
+    "hit after mset" in {
+      Cache.mSet( s"$prefix-test-mset-1" -> "value-1", s"$prefix-test-mset-2" -> "value-2" ).sync
+      Cache.mGet[ String ]( s"$prefix-test-mset-1", s"$prefix-test-mset-2" ).sync must beEqualTo( List( Some( "value-1" ), Some( "value-2" ) ) )
+    }
+
+    "ignore msetnx if already defined" in {
+      Cache.mSetIfNotExist( s"$prefix-test-msetnx-1" -> "value-1", s"$prefix-test-msetnx-2" -> "value-2" ) must beTrue
+      Cache.mGet[ String ]( s"$prefix-test-msetnx-1", s"$prefix-test-msetnx-2" ).sync must beEqualTo( List( Some( "value-1" ), Some( "value-2" ) ) )
+      Cache.mSetIfNotExist( s"$prefix-test-msetnx-3" -> "value-3", s"$prefix-test-msetnx-2" -> "value-2" ) must beFalse
     }
 
     "expire refreshes expiration" in {

--- a/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/RedisConnectorSpec.scala
@@ -3,10 +3,8 @@ package play.api.cache.redis.connector
 import java.util.Date
 
 import scala.concurrent.duration._
-
 import play.api.cache.redis._
 import play.api.cache.redis.exception.ExecutionFailedException
-
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 
@@ -31,6 +29,11 @@ class RedisConnectorSpec extends Specification with Redis {
       Cache.set( s"$prefix-test-2", "value" ).sync
       Cache.get[ String ]( s"$prefix-test-2" ) must beSome[ Any ]
       Cache.get[ String ]( s"$prefix-test-2" ) must beSome( "value" )
+    }
+
+    "hit after mset" in {
+      Cache.mSet(Map(s"$prefix-test-2-1" -> "value-1", s"$prefix-test-2-2" -> "value-2") ).sync
+      Cache.mGet[ String ]( s"$prefix-test-2-1", s"$prefix-test-2-2" ).sync must beEqualTo(List(Some("value-1"), Some("value-2")))
     }
 
     "ignore set if not exists when already defined" in {

--- a/src/test/scala/play/api/cache/redis/connector/ScRedisSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/ScRedisSpec.scala
@@ -1,11 +1,11 @@
 package play.api.cache.redis.connector
 
 import scala.concurrent.Future
-
 import play.api.cache.redis.{Redis, RedisInstance}
-
 import org.specs2.matcher.MustExpectable
 import org.specs2.mutable.Specification
+
+import scala.collection.immutable.List
 
 /**
  * <p>Test of brando to be sure that it works etc.</p>
@@ -26,16 +26,30 @@ class ScRedisSpec extends Specification with Redis with RedisInstance {
       redis.set( "some-key", "this-value" ) must beTrue
     }
 
+    "set values" in {
+      redis.mSet( Map("some-key1" -> "this-value", "some-key2" -> "that-value")) must not beNull
+    }
+
     "get stored value" in {
       redis.get[ String ]( "some-key" ) must beSome( "this-value" )
+    }
+
+    "get stored values" in {
+      redis.mGet[ String ]( "some-key1", "some-key2" ) must beEqualTo(List(Some("this-value"), Some("that-value")))
+    }
+
+    "get stored key values" in {
+      redis.mGetAsMap[ String ]( "some-key1", "some-key2" ) must beEqualTo(Map("some-key1" -> "this-value", "some-key2" -> "that-value"))
     }
 
     "get non-existing value" in {
       redis.get[ String ]( "non-existing" ) must beNone
     }
 
-    "determine whether it contains already stored key" in {
+    "determine whether it contains already stored keys" in {
       redis.exists( "some-key" ) must beTrue
+      redis.exists( "some-key1" ) must beTrue
+      redis.exists( "some-key2" ) must beTrue
     }
 
     "determine whether it contains non-existent key" in {
@@ -43,7 +57,7 @@ class ScRedisSpec extends Specification with Redis with RedisInstance {
     }
 
     "delete stored value" in {
-      redis.del( "some-key" ) must beEqualTo( 1L )
+      redis.del( "some-key", "some-key1", "some-key2" ) must beEqualTo( 3L )
     }
 
     "delete already deleted value" in {
@@ -54,8 +68,10 @@ class ScRedisSpec extends Specification with Redis with RedisInstance {
       redis.del( "non-existing" ) must beEqualTo( 0L )
     }
 
-    "determine whether it contains deleted key" in {
+    "determine whether it contains deleted keys" in {
       redis.exists( "some-key" ) must beFalse
+      redis.exists( "some-key1" ) must beFalse
+      redis.exists( "some-key2" ) must beFalse
     }
   }
 }

--- a/src/test/scala/play/api/cache/redis/connector/ScRedisSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/ScRedisSpec.scala
@@ -1,15 +1,15 @@
 package play.api.cache.redis.connector
 
 import scala.concurrent.Future
+
 import play.api.cache.redis.{Redis, RedisInstance}
+
 import org.specs2.matcher.MustExpectable
 import org.specs2.mutable.Specification
 
-import scala.collection.immutable.List
-
 /**
- * <p>Test of brando to be sure that it works etc.</p>
- */
+  * <p>Test of brando to be sure that it works etc.</p>
+  */
 class ScRedisSpec extends Specification with Redis with RedisInstance {
 
   sequential
@@ -19,7 +19,7 @@ class ScRedisSpec extends Specification with Redis with RedisInstance {
   "ScRedis" should {
 
     "ping" in {
-      redis.ping( ) must beEqualTo( "PONG" )
+      redis.ping() must beEqualTo( "PONG" )
     }
 
     "set value" in {
@@ -27,7 +27,7 @@ class ScRedisSpec extends Specification with Redis with RedisInstance {
     }
 
     "set values" in {
-      redis.mSet( Map("some-key1" -> "this-value", "some-key2" -> "that-value")) must not beNull
+      redis.mSet( Map( "some-key1" -> "this-value", "some-key2" -> "that-value" ) ) must not( beNull )
     }
 
     "get stored value" in {
@@ -35,11 +35,11 @@ class ScRedisSpec extends Specification with Redis with RedisInstance {
     }
 
     "get stored values" in {
-      redis.mGet[ String ]( "some-key1", "some-key2" ) must beEqualTo(List(Some("this-value"), Some("that-value")))
+      redis.mGet[ String ]( "some-key1", "some-key2" ) must beEqualTo( List( Some( "this-value" ), Some( "that-value" ) ) )
     }
 
     "get stored key values" in {
-      redis.mGetAsMap[ String ]( "some-key1", "some-key2" ) must beEqualTo(Map("some-key1" -> "this-value", "some-key2" -> "that-value"))
+      redis.mGetAsMap[ String ]( "some-key1", "some-key2" ) must beEqualTo( Map( "some-key1" -> "this-value", "some-key2" -> "that-value" ) )
     }
 
     "get non-existing value" in {

--- a/src/test/scala/play/api/cache/redis/impl/PlayCacheSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/PlayCacheSpec.scala
@@ -54,5 +54,12 @@ class PlayCacheSpec extends Specification with Redis {
       Cache.remove( s"$prefix-test-3" )
       Cache.get[ String ]( s"$prefix-test-3" ) must beNone
     }
+
+    "work with batch operations" in {
+      Cache.mSet( Map(s"$prefix-test-4-1" -> "value-1", s"$prefix-test-4-2" -> "value-2") )
+      Cache.mGet[ String ]( s"$prefix-test-4-1", s"$prefix-test-4-2" ) must beEqualTo(List(Some("value-1"), Some("value-2")))
+      Cache.remove( s"$prefix-test-3" )
+      Cache.get[ String ]( s"$prefix-test-3" ) must beNone
+    }
   }
 }

--- a/src/test/scala/play/api/cache/redis/impl/PlayCacheSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/PlayCacheSpec.scala
@@ -56,10 +56,11 @@ class PlayCacheSpec extends Specification with Redis {
     }
 
     "work with batch operations" in {
-      Cache.mSet( Map(s"$prefix-test-4-1" -> "value-1", s"$prefix-test-4-2" -> "value-2") )
-      Cache.mGet[ String ]( s"$prefix-test-4-1", s"$prefix-test-4-2" ) must beEqualTo(List(Some("value-1"), Some("value-2")))
-      Cache.remove( s"$prefix-test-3" )
-      Cache.get[ String ]( s"$prefix-test-3" ) must beNone
+      Cache.setAll( s"$prefix-test-4-1" -> "value-1", s"$prefix-test-4-2" -> "value-2" )
+      Cache.getAll[ String ]( s"$prefix-test-4-1", s"$prefix-test-4-2" ) must beEqualTo( List( Some( "value-1" ), Some( "value-2" ) ) )
+      Cache.remove( s"$prefix-test-4-1" )
+      Cache.get[ String ]( s"$prefix-test-4-1" ) must beNone
+      Cache.getAll[ String ]( s"$prefix-test-4-1", s"$prefix-test-4-2" ) must beEqualTo( List( None, Some( "value-2" ) ) )
     }
   }
 }


### PR DESCRIPTION
Fixes #80, fixes #81 

Implements  #80 using #81 - just refactored, fixed several issues plus added SETNX and updated readme

@pcejrowski Thanks for your PR. Great job! I admire you understood my code. Well done! Could you look at this? I used your PR and just refactored it plus made several improvements. The major change comparing to your PR is that I renamed the methods in CacheAPI and changed their signature. It seems to me that this fits better the CacheAPI intention. CacheAPI should be independent on commands thus I don't like MGET and MSET names and I like varargs signature and want to be consistent with the rest of the API. But if it turns out that the using the Map is a frequent scenario, I will overload the method.