### PR TITLE
Checked serialization exception

### DIFF
--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -6,3 +6,14 @@ akka.actor.warn-about-java-serializer-usage = off
 
 # connection timeout in milliseconds
 play.cache.redis.timeout:    3s
+
+akka {
+  actor {
+    serialization-bindings {
+      "play.api.cache.redis.impl.UnserializableObject" = failing
+    }
+    serializers {
+      failing = "play.api.cache.redis.impl.FailingSerializer"
+    }
+  }
+}

--- a/src/test/scala/play/api/cache/redis/impl/package.scala
+++ b/src/test/scala/play/api/cache/redis/impl/package.scala
@@ -60,6 +60,10 @@ package object impl extends LowPriorityImplicits {
     override def expectsNow[ T ]( success: => Matcher[ T ], default: => Matcher[ T ], exception: => Matcher[ T ] ): Matcher[ T ] = success
   }
 
+  object SuccessOrDefault extends Expectation {
+    override def expectsNow[ T ]( success: => Matcher[ T ], default: => Matcher[ T ], exception: => Matcher[ T ] ): Matcher[ T ] = success or default
+  }
+
   object beUnit extends Matcher[ Any ] {
     def apply[ S <: Any ]( value: Expectable[ S ] ): MatchResult[ S ] = result( test = true, value.description + " is Unit", value.description + " is not Unit", value.evaluate )
   }


### PR DESCRIPTION
Fixes #83 

All encodings are invoked inside of `Future` to ensure the exceptions to be thrown as a rejected `Future` instance.