### PR TITLE
Use Future.successful and Future.failed where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class MyController @Inject() ( cache: CacheApi ) {
   cache.getOrElse( "key" )( 1.24 )
 
   // same as getOrElse but works for Futures. It returns Future[ T ]
-  cache.getOrFuture( "key" )( Future( 1.24 ) )
+  cache.getOrFuture( "key" )( Future.successful( 1.24 ) )
 
   // returns Unit and removes a key/keys from the storage
   cache.remove( "key" )

--- a/src/main/scala/play/api/cache/redis/connector/RedisConnectorImpl.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisConnectorImpl.scala
@@ -82,10 +82,10 @@ private[ connector ] class RedisConnectorImpl @Inject()( serializer: AkkaSeriali
     else encode( key, value ) flatMap ( setEternally( key, _ ) )
 
   /** encodes the object, reports an exception if fails */
-  private def encode( key: String, value: Any ): Future[ String ] = Future {
+  private def encode( key: String, value: Any ): Future[ String ] = Future.fromTry {
     serializer.encode( value ).recover {
       case ex => serializationFailed( key, "Serialization failed", ex )
-    }.get
+    }
   }
 
   /** temporally stores already encoded value into the storage */
@@ -167,7 +167,7 @@ private[ connector ] class RedisConnectorImpl @Inject()( serializer: AkkaSeriali
         // Some entries were removed
         case removed => log.debug( s"Remove on keys ${ keys.mkString( "'", ",", "'" ) } removed $removed values." )
       }
-    else Future( Unit ) // otherwise return immediately
+    else Future.successful( Unit ) // otherwise return immediately
 
   def ping( ): Future[ Unit ] =
     redis.ping() executing "PING" expects {

--- a/src/main/scala/play/api/cache/redis/impl/dsl.scala
+++ b/src/main/scala/play/api/cache/redis/impl/dsl.scala
@@ -14,7 +14,7 @@ private[ impl ] object dsl {
 
   /** enriches any ref by toFuture converting a value to Future.successful */
   implicit class RichFuture[ T ]( val any: T ) extends AnyVal {
-    @inline def toFuture( ): Future[ T ] = Future.successful( any )
+    @inline def toFuture: Future[ T ] = Future.successful( any )
   }
 
   /** helper function enabling us to recover from command execution */

--- a/src/main/scala/play/api/cache/redis/impl/dsl.scala
+++ b/src/main/scala/play/api/cache/redis/impl/dsl.scala
@@ -14,7 +14,7 @@ private[ impl ] object dsl {
 
   /** enriches any ref by toFuture converting a value to Future.successful */
   implicit class RichFuture[ T ]( val any: T ) extends AnyVal {
-    @inline def toFuture( implicit context: ExecutionContext ): Future[ T ] = Future( any )
+    @inline def toFuture( ): Future[ T ] = Future.successful( any )
   }
 
   /** helper function enabling us to recover from command execution */

--- a/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
+++ b/src/test/scala/play/api/cache/redis/connector/FailingConnector.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 
 import play.api.cache.redis.Synchronization
-import play.api.cache.redis.exception.failed
+import play.api.cache.redis.exception.ExecutionFailedException
 
 /**
   * @author Karel Cemus
@@ -16,12 +16,12 @@ object FailingConnector extends RedisConnector with Synchronization {
 
   private def theError = new IllegalStateException( "Redis connector failure reproduction" )
 
-  private def failKeyed( key: String, command: String ) = Future {
-    failed( Some( key ), command, theError )
+  private def failKeyed( key: String, command: String ) = Future.failed {
+    ExecutionFailedException( Some( key ), command, theError )
   }
 
-  private def failCommand( command: String ) = Future {
-    failed( None, command, theError )
+  private def failCommand( command: String ) = Future.failed {
+    ExecutionFailedException( None, command, theError )
   }
 
   def set( key: String, value: Any, expiration: Duration ): Future[ Unit ] =

--- a/src/test/scala/play/api/cache/redis/impl/package.scala
+++ b/src/test/scala/play/api/cache/redis/impl/package.scala
@@ -100,7 +100,7 @@ trait LowPriorityImplicits {
 
     /** invokes internal getOrElse but it accumulate invocations of orElse clause in the accumulator */
     def getOrFutureCounting( key: String )( accumulator: Accumulator ) = cache.getOrFuture[ String ]( key ) {
-      Future {
+      Future.successful {
         // increment miss counter
         accumulator.incrementAndGet()
         // return the value to store into the cache


### PR DESCRIPTION
`Future.apply` actually submits work to the `ExecutionContext` possibly running on a different thread. For the expressions that don't need to run on another thread, `Future.successful` and `Future.failed` can be used to return immediate values more efficiently.