### PR TITLE
Changed default database from 1 to 0 to remove the inconsistency

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ play.cache.redis {
   # redis server: port
   port:       6379
   # redis server: database number
-  database:   1
+  database:   0
 
   # there are two ways to configure redis instances.
   #
@@ -28,7 +28,7 @@ play.cache.redis {
   #   # redis server: port
   #   port:       6379
   #   # redis server: database number
-  #   database:   1
+  #   database:   0
   # }
   #
   # for more advanced settings such as a cluster or connection
@@ -68,7 +68,7 @@ play.cache.redis {
   #   # redis server: port
   #   port:       6379
   #   # redis server: database number
-  #   database:   1
+  #   database:   0
   #   # when authentication is required, define the password. The argument is optional
   #   password:   null
   #


### PR DESCRIPTION
This PR resolves this from #107:

> Configuration / Standalone vs. Cluster: it's outside of Wikis scope, but still default database is 1, which might be confusing comparing with the Redis default DB equal 0. I think we discussed that, but I don't remember the outcome