### PR TITLE
Registered binding of AsyncCacheApi

### DIFF
--- a/src/main/scala/play/api/cache/redis/RedisCacheModule.scala
+++ b/src/main/scala/play/api/cache/redis/RedisCacheModule.scala
@@ -61,6 +61,7 @@ object GuiceProvider {
       // expose a single-implementation providers
       namedBinding( _.sync ),
       namedBinding( _.async ),
+      namedBinding( _.scalaAsync ),
       namedBinding( _.scalaSync ),
       namedBinding( _.javaSync ),
       namedBinding( _.javaAsync )
@@ -78,6 +79,7 @@ object GuiceProvider {
       defaultBinding[ CacheApi ],
       defaultBinding[ CacheAsyncApi ],
       defaultBinding[ play.api.cache.SyncCacheApi ],
+      defaultBinding[ play.api.cache.AsyncCacheApi ],
       defaultBinding[ play.cache.SyncCacheApi ],
       defaultBinding[ play.cache.AsyncCacheApi ]
     )

--- a/src/main/scala/play/api/cache/redis/impl/RedisCaches.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCaches.scala
@@ -17,6 +17,7 @@ import akka.actor.ActorSystem
 trait RedisCaches {
   def sync: CacheApi
   def async: CacheAsyncApi
+  def scalaAsync: play.api.cache.AsyncCacheApi
   def scalaSync: play.api.cache.SyncCacheApi
   def javaSync: play.cache.SyncCacheApi
   def javaAsync: play.cache.AsyncCacheApi
@@ -33,6 +34,7 @@ private[ redis ] class RedisCachesProvider( instance: RedisInstance, serializer:
     lazy val async =  new AsyncRedis( redisConnector )
     lazy val sync = new SyncRedis( redisConnector )
     lazy val scalaSync = new play.api.cache.DefaultSyncCacheApi( async )
+    lazy val scalaAsync = async
     lazy val java = new JavaRedis( async, environment )
     lazy val javaAsync = new play.cache.DefaultAsyncCacheApi( async )
     lazy val javaSync = new play.cache.DefaultSyncCacheApi( java )


### PR DESCRIPTION
Version 2.0.0 does not bind any implementation to Scala async api. This PR fixes #135 