### PR TITLE
Published snapshots no longer depends on scoverage runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - secure: ozghyo5Yp3enkBx53MzQaD0LeqhBNbGFC3vkkZAcQbele4tR5GrOzR4xjTH0oHhVj7NUHq7WGu4nUDj1h43fJW7uCViepUARrBMPLaUc8ba036IX1OXTU7e2ilGKnOsFeOGfgOo9tb5HnisgfhSXAfMBCgigc+oCtL0HTBdxn9CqjqsUo23c/fnG2UKyLk0Hv5vp91Z/3+kMNkxQTMdJs+ywpKRbMHdIwkghJIqSVfezGxmqhi1wSfoh0xMjOQjaHC0NpTWUs+gmD0hENzV/THwtkeLNcIsdkMIJPoPKruOlfGeTnCFHF3ojNgrUEEDwulrwpLTLoQJeDU6P60JSwUdtzu9hSxwTZLgndwmaE77r2cVsiD5xM5AGB4jVQbd9oOFMW7TIErUemg53qFAiix1W5KtgGv6vW9qT7Z/CRpYC2LG99BUnNzdTKu9e2oBsCY1QbYrXHORSqefnzihAlwJ/6lAGDLnAFw4pgYb779oo8GIhQQdCDMqELSunhP8uJ6G3dpY5p5ubrsSA7yS6tRcaQ+iB1410iTNfMAoD0tKIjgbpR4Zs8lg/5bpiO914f3Xf0KKwFM7lXdajMdN5z5iDnOGgAgtwXB1a/QT2phHqKQ/DFLUbqVUdE2tmuycJ9iAUtVVsyOXZggtOun6o04hfBG1NK/tc1ifGUPigjXw=
   - secure: b1gPGCnIdQPqvztIFzM1JkVqYhgDSx5KC273sg9/I2f9zAP+YqPgJ9WjdUBj2Wp2pzQdggakdBgAj36cpEhpylr4W2t4aMzHitvmu/BvHW9+vpjzMhqpLP/6GG8N+Szbhm3nj4BDA/BjelTnN2SyvKrxWGrD6QJuU33AakWM3v/b/Og5L2Sb2E63X80i2iZk9qTdOHCoTxizkTtB/DEgt9PpzUfMJmn8Ww1Gs1mbou3fPUPOVO88iBjn5JmF6iJ+sIRY0MQuPHhDnk98z6BvITg8GycQBc27OWzJFxK0Zu78MVV3t8WRjZ0sxyJNwdGSBBdz5L1jEzP5J5GtgRZiCcCOVZ4j04kdd2/2/4RaZX2jdZAyr1uzIEuBY+xwKhg6J0386HGrQVUu+IvgPQbpFOtmDeyIBRRAXW11KXR2+cNH6RFF8wA274G8l3SAfvvpWKUwussj9j3h1T/37xdCL2igaOmbOEIQYL1Mpo5cnN8lI080LoCc5vL9XHqCVlE7Hr+VUhoagmuiMMUzrTW0Rg81fI+I8dswyy6QTaqY8EYg8KdxQhDoFnkRtHAdaJyjWrL7IuM5G1Poto9UkW8Gg4YwK5HHeg9xDaLMD/OBnup2DVIqwsi2walsM6OlLB0WkEaDa2VG8WVKFOrTOLTAmfWFCscg+qutgTrfasF12EM=
 before_script:
-- ! '[[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]] && SBT_CMD="coverage test publish" || SBT_CMD="coverage test"'
+- ! '[[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]] && SBT_CMD="coverageOn test coverageOff publish" || SBT_CMD="coverage test"'
 script:
 - sbt ++$TRAVIS_SCALA_VERSION $SBT_CMD
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### [:link: 2.1.0](https://github.com/KarelCemus/play-redis/tree/2.1.0)
 
+Published snapshots no longer depends on scoverage runtime [#143](https://github.com/KarelCemus/play-redis/issues/143).
+
 #### Removal of `@Named` and introduction of `@NamedCache`
 
 Named caches now uses `@NamedCache` instead of `@Named` to be consistent with Play's EhCache and 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,6 @@ addSbtPlugin( "org.scoverage" % "sbt-scoverage" % "1.5.1" )
 
 // uploads the coverage results into the coveralls.io
 addSbtPlugin( "org.scoverage" % "sbt-coveralls" % "1.2.2" )
+
+// lists project dependencies
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
There is bug in travis build which enables `coverage`. It introduces a dependency on scoverage runtime and then the publish task publishes the snapshot including this dependency. New travis script should remove this dependency.