### PR TITLE
play.cache.AsyncCacheApi is bounded to JavaRedis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## Changelog
 
+### [:link: 2.0.2](https://github.com/KarelCemus/play-redis/tree/2.0.2)
+
+`play.cache.AsyncCacheApi` is bound to `JavaRedis` instead of `DefaultAsyncCacheApi`
+ to fixed value deserialization and support Java HTTP context [#140](https://github.com/KarelCemus/play-redis/issues/140).
+
 ### [:link: 2.0.1](https://github.com/KarelCemus/play-redis/tree/2.0.1)
 
 Fixed missing binding of `play.api.cache.AsyncCacheApi` [#135](https://github.com/KarelCemus/play-redis/issues/135).

--- a/src/main/scala/play/api/cache/redis/impl/RedisCaches.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCaches.scala
@@ -36,7 +36,7 @@ private[ redis ] class RedisCachesProvider( instance: RedisInstance, serializer:
     lazy val scalaSync = new play.api.cache.DefaultSyncCacheApi( async )
     lazy val scalaAsync = async
     lazy val java = new JavaRedis( async, environment )
-    lazy val javaAsync = new play.cache.DefaultAsyncCacheApi( async )
+    lazy val javaAsync = java
     lazy val javaSync = new play.cache.DefaultSyncCacheApi( java )
   }
 }


### PR DESCRIPTION
Backport of #144 fixing #140