### PR TITLE
Revamped InvocationPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,15 @@ binding should still work. The warnings can be disabled through the logger confi
 the support will be fully removed in the `2.2.0`. The complex scenarios with the custom 
 `RedisInstance` or `RedisCaches` have to be migrated right away, there is no fallback binding.
 
-**Note**: `RecoveryPolicy` still uses `@Named` as it neither is nor relates to any particular cache. 
+**Note**: `RecoveryPolicy` still uses `@Named` as it neither is nor relates to any particular cache.
+
+#### Revamped Invocation Policy
+
+Dropped implicit `InvocationPolicy` from Scala version of the API,
+replaced by the instance configuration through the config file.
+Introduced configuration property `invocation`. It works also with JavaRedis.
+For more details, see [the updated documentation](https://github.com/KarelCemus/play-redis/wiki/Configuration#invocation-policy)
+ [#147](https://github.com/KarelCemus/play-redis/issues/147).
 
 ### [:link: 2.0.2](https://github.com/KarelCemus/play-redis/tree/2.0.2)
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -171,6 +171,22 @@ play.cache.redis {
   #
   dispatcher:       akka.actor.default-dispatcher
 
+  # invocation policy applies in methods `getOrElse`. It determines
+  # whether to wait until the `set` completes or return eagerly the
+  # computed value. Valid values:
+  #  - 'lazy':  for lazy invocation waiting for the `set` completion
+  #  - 'eager': for eager invocation returning the computed on miss
+  #             without waiting for the `set` completion. Eager
+  #             invocation ignores the error in `set`, if occurs.
+  #
+  # Default value is 'lazy' to properly handle errors, if occurs.
+  #
+  # note: this is global definition, can be locally overriden for each
+  # cache instance. To do so, redefine this property
+  # under 'play.cache.redis.instances.instance-name.this-property'.
+  #
+  invocation:       lazy
+
   # The intention of cache is usually to optimize the application behavior,
   # not to provide any business logic, i.e., it makes sense the cache could
   # be removed without any visible change except for possible performance loss.

--- a/src/main/scala/play/api/cache/redis/CacheApi.scala
+++ b/src/main/scala/play/api/cache/redis/CacheApi.scala
@@ -44,7 +44,7 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     * @param orElse     The default function to invoke if the value was not found in cache.
     * @return stored or default record, Some if exists, otherwise None
     */
-  def getOrElse[ T: ClassTag ]( key: String, expiration: Duration = Duration.Inf )( orElse: => T )( implicit invocation: InvocationPolicy = LazyInvocation ): Result[ T ]
+  def getOrElse[ T: ClassTag ]( key: String, expiration: Duration = Duration.Inf )( orElse: => T ): Result[ T ]
 
   /** Retrieve a value from the cache. If is missing, set default value with
     * given expiration and return the value.
@@ -61,7 +61,7 @@ private[ redis ] trait AbstractCacheApi[ Result[ _ ] ] {
     * @param orElse     The default function to invoke if the value was not found in cache.
     * @return stored or default record, Some if exists, otherwise None
     */
-  def getOrFuture[ T: ClassTag ]( key: String, expiration: Duration = Duration.Inf )( orElse: => Future[ T ] )( implicit invocation: InvocationPolicy = LazyInvocation ): Future[ T ]
+  def getOrFuture[ T: ClassTag ]( key: String, expiration: Duration = Duration.Inf )( orElse: => Future[ T ] ): Future[ T ]
 
   /** Determines whether value exists in cache.
     *

--- a/src/main/scala/play/api/cache/redis/impl/InvocationPolicy.scala
+++ b/src/main/scala/play/api/cache/redis/impl/InvocationPolicy.scala
@@ -1,4 +1,4 @@
-package play.api.cache.redis
+package play.api.cache.redis.impl
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,13 +13,13 @@ import scala.concurrent.{ExecutionContext, Future}
   * @author Karel Cemus
   */
 sealed trait InvocationPolicy {
-  def invoke[ T ]( f: => Future[ Unit ], thenReturn: T )( implicit context: ExecutionContext ): Future[ T ]
+  def invoke[ T ]( f: => Future[ Any ], thenReturn: T )( implicit context: ExecutionContext ): Future[ T ]
 }
 
 object EagerInvocation extends InvocationPolicy {
-  def invoke[ T ]( f: => Future[ Unit ], thenReturn: T )( implicit context: ExecutionContext ) = { f; Future successful thenReturn }
+  def invoke[ T ]( f: => Future[ Any ], thenReturn: T )( implicit context: ExecutionContext ) = { f; Future successful thenReturn }
 }
 
 object LazyInvocation extends InvocationPolicy {
-  def invoke[ T ]( f: => Future[ Unit ], thenReturn: T )( implicit context: ExecutionContext ) = f.map( _ => thenReturn )
+  def invoke[ T ]( f: => Future[ Any ], thenReturn: T )( implicit context: ExecutionContext ) = f.map( _ => thenReturn )
 }

--- a/src/main/scala/play/api/cache/redis/impl/JavaRedis.scala
+++ b/src/main/scala/play/api/cache/redis/impl/JavaRedis.scala
@@ -67,7 +67,9 @@ private[ impl ] class JavaRedis( internal: CacheAsyncApi, environment: Environme
     // compute or else and save it into cache
     def orElse( callable: Callable[ CompletionStage[ T ] ] ) = callable.call().toScala
     def saveOrElse( value: T ) = set( key, value, duration )
-    def savedOrElse( callable: Callable[ CompletionStage[ T ] ] ) = orElse( callable ).flatMap { value => saveOrElse( value ).map( _ => Some( value ) ) }
+    def savedOrElse( callable: Callable[ CompletionStage[ T ] ] ) = orElse( callable ).flatMap {
+      value => runtime.invocation.invoke( saveOrElse( value ), Some( value ) )
+    }
 
     getValue.flatMap {
       case Some( value ) => Future.successful( Some( value ) )

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -58,16 +58,16 @@ private[ impl ] class RedisCache[ Result[ _ ] ]( redis: RedisConnector, builder:
     redis.matching( pattern ).recoverWithDefault( Seq.empty[ String ] )
   }
 
-  def getOrElse[ T: ClassTag ]( key: String, expiration: Duration )( orElse: => T )( implicit invocation: InvocationPolicy ) = key.prefixed { key =>
+  def getOrElse[ T: ClassTag ]( key: String, expiration: Duration )( orElse: => T ) = key.prefixed { key =>
     getOrFuture( key, expiration )( orElse.toFuture ).recoverWithDefault( orElse )
   }
 
-  def getOrFuture[ T: ClassTag ]( key: String, expiration: Duration )( orElse: => Future[ T ] )( implicit invocation: InvocationPolicy ): Future[ T ] = key.prefixed { key =>
+  def getOrFuture[ T: ClassTag ]( key: String, expiration: Duration )( orElse: => Future[ T ] ): Future[ T ] = key.prefixed { key =>
     redis.get[ T ]( key ).flatMap {
       // cache hit, return the unwrapped value
       case Some( value: T ) => value.toFuture
       // cache miss, compute the value, store it into the cache but do not wait for the result and ignore it, directly return the value
-      case None => orElse flatMap { value => invocation.invoke( redis.set( key, value, expiration ), thenReturn = value ) }
+      case None => orElse flatMap { value => runtime.invocation.invoke( redis.set( key, value, expiration ), thenReturn = value ) }
     }.recoverWithFuture( orElse )
   }
 

--- a/src/main/scala/play/api/cache/redis/impl/RedisCaches.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCaches.scala
@@ -26,7 +26,7 @@ trait RedisCaches {
 private[ redis ] class RedisCachesProvider( instance: RedisInstance, serializer: connector.AkkaSerializer, environment: Environment )( implicit system: ActorSystem, lifecycle: ApplicationLifecycle, recovery: RecoveryPolicyResolver ) extends Provider[ RedisCaches ] {
   import RedisRuntime._
 
-  private implicit lazy val runtime: RedisRuntime = RedisRuntime( instance, instance.recovery, instance.prefix )( system )
+  private implicit lazy val runtime: RedisRuntime = RedisRuntime( instance, instance.recovery, instance.invocationPolicy, instance.prefix )( system )
 
   private lazy val redisConnector = new connector.RedisConnectorProvider( instance, serializer ).get
 

--- a/src/test/scala/play/api/cache/redis/configuration/RedisInstanceManagerSpec.scala
+++ b/src/test/scala/play/api/cache/redis/configuration/RedisInstanceManagerSpec.scala
@@ -34,11 +34,12 @@ class RedisInstanceManagerSpec extends Specification {
         |
         |  dispatcher: default-dispatcher
         |  recovery:   log-and-default
+        |  invocation: lazy
         |  timeout:    1s
         |}
       """
     ) {
-      val defaults = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", timeout = 1.second, source = "standalone" )
+      val defaults = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", invocationPolicy = "lazy", timeout = 1.second, source = "standalone" )
 
       val manager = config.get[ RedisInstanceManager ]( "redis" )
       manager.caches mustEqual Set( "play", "data", "users" )
@@ -60,11 +61,12 @@ class RedisInstanceManagerSpec extends Specification {
         |  default-cache: play
         |  dispatcher:    default-dispatcher
         |  recovery:      log-and-default
+        |  invocation: lazy
         |  timeout:       1s
         |}
       """
     ) {
-      val defaults = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", timeout = 1.second, source = "standalone" )
+      val defaults = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", invocationPolicy = "lazy", timeout = 1.second, source = "standalone" )
 
       val manager = config.get[ RedisInstanceManager ]( "redis" )
       manager.caches mustEqual Set( "play" )

--- a/src/test/scala/play/api/cache/redis/configuration/RedisInstanceSpec.scala
+++ b/src/test/scala/play/api/cache/redis/configuration/RedisInstanceSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 class RedisInstanceSpec extends Specification {
 
   // settings builder
-  def settings( source: String ) = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", timeout = 1.second, source = source )
+  def settings( source: String ) = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", invocationPolicy = "lazy", timeout = 1.second, source = source )
   // default settings
   implicit val defaults = settings( source = "standalone" )
   // implicitly expose RedisHost config loader
@@ -44,7 +44,7 @@ class RedisInstanceSpec extends Specification {
         |}
       """
     ) {
-      config.get[ RedisInstanceProvider ]( "redis" ).resolved must beEqualTo( RedisStandalone( "play", RedisHost( host = "localhost", port = 6379 ), RedisSettings( "custom-dispatcher", 2.seconds, "custom", "standalone" ) ) )
+      config.get[ RedisInstanceProvider ]( "redis" ).resolved must beEqualTo( RedisStandalone( "play", RedisHost( host = "localhost", port = 6379 ), RedisSettings( "custom-dispatcher", invocationPolicy = "lazy", 2.seconds, "custom", "standalone" ) ) )
     }
 
     "cluster" in new WithConfiguration(

--- a/src/test/scala/play/api/cache/redis/configuration/RedisSettingsSpec.scala
+++ b/src/test/scala/play/api/cache/redis/configuration/RedisSettingsSpec.scala
@@ -13,7 +13,7 @@ class RedisSettingsSpec extends Specification {
   implicit val loader = RedisSettings
 
   // default settings
-  val defaults = RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", timeout = 1.second, source = "standalone" )
+  val defaults = RedisSettings( dispatcher = "default-dispatcher", invocationPolicy = "lazy", recovery = "log-and-default", timeout = 1.second, source = "standalone" )
 
   "RedisSettings" should "read" >> {
 
@@ -22,6 +22,7 @@ class RedisSettingsSpec extends Specification {
         |redis {
         | dispatcher: default-dispatcher
         | recovery:   log-and-default
+        | invocation: lazy
         | timeout:    1s
         | source:     standalone
         |}
@@ -36,7 +37,7 @@ class RedisSettingsSpec extends Specification {
         |}
       """
     ) {
-      config.get( "redis" )( RedisSettings.withFallback( defaults ) ) mustEqual RedisSettings( dispatcher = "default-dispatcher", recovery = "log-and-default", timeout = 1.second, source = "standalone" )
+      config.get( "redis" )( RedisSettings.withFallback( defaults ) ) mustEqual RedisSettings( dispatcher = "default-dispatcher", invocationPolicy = "lazy", recovery = "log-and-default", timeout = 1.second, source = "standalone" )
     }
 
     "filled with fallback" in new WithConfiguration(
@@ -44,12 +45,13 @@ class RedisSettingsSpec extends Specification {
         |redis {
         | dispatcher: custom-dispatcher
         | recovery:   custom
+        | invocation: lazy
         | timeout:    2s
         | source:     cluster
         |}
       """
     ) {
-      config.get( "redis" )( RedisSettings.withFallback( defaults ) ) mustEqual RedisSettings( dispatcher = "custom-dispatcher", recovery = "custom", timeout = 2.second, source = "cluster" )
+      config.get( "redis" )( RedisSettings.withFallback( defaults ) ) mustEqual RedisSettings( dispatcher = "custom-dispatcher", invocationPolicy = "lazy", recovery = "custom", timeout = 2.second, source = "cluster" )
     }
   }
 }

--- a/src/test/scala/play/api/cache/redis/impl/RedisListSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/RedisListSpec.scala
@@ -18,7 +18,7 @@ class RedisListSpec extends Specification with Redis {
 
   private val workingConnector = injector.instanceOf[ RedisConnector ]
 
-  def runtime( policy: RecoveryPolicy ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, policy )
+  def runtime( policy: RecoveryPolicy ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, policy, invocation = LazyInvocation )
 
   // test proper implementation, no fails
   new RedisListSuite( "implement", "redis-cache-implements", new RedisCache( workingConnector, Builders.SynchronousBuilder )( runtime( FailThrough ) ), AlwaysSuccess )

--- a/src/test/scala/play/api/cache/redis/impl/RedisMapSpecs.scala
+++ b/src/test/scala/play/api/cache/redis/impl/RedisMapSpecs.scala
@@ -20,7 +20,7 @@ class RedisMapSpecs extends Specification with Redis {
 
   private val workingConnector = injector.instanceOf[ RedisConnector ]
 
-  implicit def runtime( policy: RecoveryPolicy ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, policy )
+  implicit def runtime( policy: RecoveryPolicy ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, policy, invocation = LazyInvocation )
 
   // test proper implementation, no fails
   new RedisMapSuite( "implement", "redis-cache-implements", new RedisCache( workingConnector, Builders.SynchronousBuilder )( FailThrough ), AlwaysSuccess )

--- a/src/test/scala/play/api/cache/redis/impl/RedisPrefixSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/RedisPrefixSpec.scala
@@ -17,7 +17,7 @@ class RedisPrefixSpec extends Specification with Redis { outer =>
 
   private val workingConnector = injector.instanceOf[ RedisConnector ]
 
-  def runtime( prefix: Option[ String ] ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, FailThrough, prefix )
+  def runtime( prefix: Option[ String ] ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, FailThrough, invocation = LazyInvocation, prefix )
 
   val unprefixed = new RedisCache( workingConnector, Builders.SynchronousBuilder )( runtime( prefix = None ) )
 

--- a/src/test/scala/play/api/cache/redis/impl/RedisSetSpecs.scala
+++ b/src/test/scala/play/api/cache/redis/impl/RedisSetSpecs.scala
@@ -20,7 +20,7 @@ class RedisSetSpecs extends Specification with Redis {
 
   private val workingConnector = injector.instanceOf[ RedisConnector ]
 
-  implicit def runtime( policy: RecoveryPolicy ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, policy )
+  implicit def runtime( policy: RecoveryPolicy ) =  RedisRuntime( "play", 3.minutes, ExecutionContext.Implicits.global, policy, invocation = LazyInvocation )
 
   // test proper implementation, no fails
   new RedisSetSuite( "implement", "redis-cache-implements", new RedisCache( workingConnector, Builders.SynchronousBuilder )( FailThrough ), AlwaysSuccess )


### PR DESCRIPTION
- dropped implicit `InvocationPolicy` from Scala version of the API
- replaced by the instance configuration through the config file
- works also with JavaRedis

Relates to #147 