### PR TITLE
Bumped rediscala to 1.8.2 and Akka 2.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
 - oraclejdk8
 scala:
 - 2.11.11
-- 2.12.3
+- 2.12.5
 branches:
   only:
   - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Introduced configuration property `invocation`. It works also with JavaRedis.
 For more details, see [the updated documentation](https://github.com/KarelCemus/play-redis/wiki/Configuration#invocation-policy)
  [#147](https://github.com/KarelCemus/play-redis/issues/147).
 
+### [:link: 2.0.3](https://github.com/KarelCemus/play-redis/tree/2.0.3)
+
+Rediscala bumped to 1.8.3 and subsequently Akka bumped to 2.5.6 [#150](https://github.com/KarelCemus/play-redis/issues/150).
+
 ### [:link: 2.0.2](https://github.com/KarelCemus/play-redis/tree/2.0.2)
 
 `play.cache.AsyncCacheApi` is bound to `JavaRedis` instead of `DefaultAsyncCacheApi`

--- a/build.sbt
+++ b/build.sbt
@@ -11,15 +11,15 @@ description := "Redis cache plugin for the Play framework 2"
 
 organization := "com.github.karelcemus"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.5"
 
 crossScalaVersions := Seq( "2.11.12", scalaVersion.value )
 
-val playVersion = "2.6.11"
+val playVersion = "2.6.12"
 
-val connectorVersion = "1.8.0"
+val connectorVersion = "1.8.3"
 
-val specs2Version = "4.0.2"
+val specs2Version = "4.0.3"
 
 parallelExecution in Test := false
 
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   // play framework cache API
   "com.typesafe.play" %% "play-cache" % playVersion % Provided,
   // redis connector
-  "com.github.etaty" %% "rediscala" % connectorVersion,
+  "com.github.Ma27" %% "rediscala" % connectorVersion,
   // test framework
   "org.specs2" %% "specs2-core" % specs2Version % Test,
   // test module for play framework

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.1


### PR DESCRIPTION
Fixes #150 

@pandian-egnaroinc I updated the rediscala to version 1.8.2, which uses Akka 2.5.6. However, there are new maintainers so I'm not sure and convinced about its stability. Could you test this snapshot before I merge it to master, please?

I ran the tests within play-redis (517) and all passed, so I hope it should work.