### PR TITLE
Redis standalone client fails eagerly when disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Published snapshots no longer depends on scoverage runtime [#143](https://github
 
 `play.cache.AsyncCacheApi` is bound to `JavaRedis` instead of `DefaultAsyncCacheApi`
  to fixed value deserialization and support Java HTTP context [#140](https://github.com/KarelCemus/play-redis/issues/140).
+ 
+Standalone client now fails eagerly when the connection to redis is not
+established. This is to avoid long timeout while the rediscala is trying
+to reconnect. [#147](https://github.com/KarelCemus/play-redis/issues/147)
 
 #### Removal of `@Named` and introduction of `@NamedCache`
 

--- a/src/main/scala/play/api/cache/redis/connector/FailEagerly.scala
+++ b/src/main/scala/play/api/cache/redis/connector/FailEagerly.scala
@@ -1,9 +1,11 @@
 package play.api.cache.redis.connector
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
+import akka.actor._
+import akka.pattern._
 import redis._
-
 
 /**
   * Actor extension maintaining current connected status.
@@ -12,13 +14,24 @@ import redis._
   * instead.
   *
   */
-trait FailEagerly extends redis.Request {
+trait FailEagerly extends Request {
 
   protected var connected = false
 
+  protected val scheduler: Scheduler
+
+  /** max timeout of the future when the redis is disconnected */
+  @inline
+  private val failAfter = 300.millis
+
   abstract override def send[ T ]( redisCommand: RedisCommand[ _ <: protocol.RedisReply, T ] ) = {
+    // proceed with the command
+    @inline def continue = super.send( redisCommand )
     // fails eagerly when the connection is not established
-    if ( connected ) super.send( redisCommand )
-    else Future.failed( redis.actors.NoConnectionException )
+    @inline def fail = after( failAfter, scheduler )( Future.failed( redis.actors.NoConnectionException ) )
+    // first completed
+    @inline def orFail = Future.firstCompletedOf( Seq( continue, fail ) )
+    // based on connection status
+    if ( connected ) continue else orFail
   }
 }

--- a/src/main/scala/play/api/cache/redis/connector/FailEagerly.scala
+++ b/src/main/scala/play/api/cache/redis/connector/FailEagerly.scala
@@ -1,0 +1,24 @@
+package play.api.cache.redis.connector
+
+import scala.concurrent.Future
+
+import redis._
+
+
+/**
+  * Actor extension maintaining current connected status.
+  * The operations are not invoked when the connection
+  * is not established, the failed future is returned
+  * instead.
+  *
+  */
+trait FailEagerly extends redis.Request {
+
+  protected var connected = false
+
+  abstract override def send[ T ]( redisCommand: RedisCommand[ _ <: protocol.RedisReply, T ] ) = {
+    // fails eagerly when the connection is not established
+    if ( connected ) super.send( redisCommand )
+    else Future.failed( redis.actors.NoConnectionException )
+  }
+}

--- a/src/main/scala/play/api/cache/redis/connector/RedisCommands.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisCommands.scala
@@ -60,12 +60,17 @@ private[ connector ] trait AbstractRedisCommands {
 private[ connector ] class RedisCommandsStandalone( configuration: RedisStandalone )( implicit system: ActorSystem, val lifecycle: ApplicationLifecycle ) extends Provider[ RedisCommands ] with AbstractRedisCommands {
   import configuration._
 
-  val client = RedisStandaloneClient(
+  val client = new RedisStandaloneClient(
     host = host,
     port = port,
     db = database,
     password = password
-  )
+  ) with FailEagerly {
+
+    override def send[ T ]( redisCommand: RedisCommand[ _ <: protocol.RedisReply, T ] ) = super.send( redisCommand )
+
+    override def onConnectStatus = ( status: Boolean ) => connected = status
+  }
 
   def start( ) = database.fold {
     log.info( s"Redis cache actor started. It is connected to $host:$port" )

--- a/src/main/scala/play/api/cache/redis/connector/RedisCommands.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisCommands.scala
@@ -67,6 +67,8 @@ private[ connector ] class RedisCommandsStandalone( configuration: RedisStandalo
     password = password
   ) with FailEagerly {
 
+    protected val scheduler = system.scheduler
+
     override def send[ T ]( redisCommand: RedisCommand[ _ <: protocol.RedisReply, T ] ) = super.send( redisCommand )
 
     override def onConnectStatus = ( status: Boolean ) => connected = status


### PR DESCRIPTION
Fixes #147 

@tzimisce012 I figured out the solution to track the connection status. Since this PR the standalone client fails eagerly when the connection is not established. Would you be kind to test it? Does it resolve the issue you've opened?