### PR TITLE
Redis cluster nodes get resolved IP address

### DIFF
--- a/src/main/scala/play/api/cache/redis/configuration/HostnameResolver.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/HostnameResolver.scala
@@ -1,0 +1,13 @@
+package play.api.cache.redis.configuration
+
+import java.net.InetAddress
+
+/**
+  * @author Karel Cemus
+  */
+object HostnameResolver {
+
+  implicit class HostNameResolver( val name: String ) extends AnyVal {
+    def resolvedIpAddress = InetAddress.getByName( name ).getHostAddress
+  }
+}

--- a/src/main/scala/play/api/cache/redis/connector/RedisCommands.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisCommands.scala
@@ -100,11 +100,12 @@ private[ connector ] class RedisCommandsStandalone( configuration: RedisStandalo
   * @param system        actor system
   */
 private[ connector ] class RedisCommandsCluster( configuration: RedisCluster )( implicit system: ActorSystem, val lifecycle: ApplicationLifecycle ) extends Provider[ RedisCommands ] with AbstractRedisCommands {
+  import HostnameResolver._
   import configuration._
 
   val client = new RedisClusterClient(
     nodes.map {
-      case RedisHost( host, port, database, password ) => RedisServer( host, port, password, database )
+      case RedisHost( host, port, database, password ) => RedisServer( host.resolvedIpAddress, port, password, database )
     }
   ) with RedisRequestTimeout {
 

--- a/src/test/scala/play/api/cache/redis/configuration/HostnameResolverSpec.scala
+++ b/src/test/scala/play/api/cache/redis/configuration/HostnameResolverSpec.scala
@@ -1,0 +1,18 @@
+package play.api.cache.redis.configuration
+
+import org.specs2.mutable.Spec
+
+/**
+  * @author Karel Cemus
+  */
+class HostnameResolverSpec extends Spec {
+  import HostnameResolver._
+
+  "hostname is resolved to IP address" in {
+    "localhost".resolvedIpAddress mustEqual "127.0.0.1"
+  }
+
+  "resolving IP address remains an address" in {
+    "127.0.0.1".resolvedIpAddress mustEqual "127.0.0.1"
+  }
+}

--- a/src/test/scala/play/api/cache/redis/connector/RedisClusterSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/RedisClusterSpec.scala
@@ -25,7 +25,7 @@ class RedisClusterSpec( implicit ee: ExecutionEnv ) extends Specification with B
 
   private val serializer = new AkkaSerializerImpl( system )
 
-  private val clusterInstance = RedisCluster( defaultCacheName, nodes = RedisHost( localhostIp, 7000 ) :: RedisHost( localhostIp, 7001 ) :: RedisHost( localhostIp, 7002 ) :: RedisHost( localhostIp, 7003 ) :: Nil, defaults )
+  private val clusterInstance = RedisCluster( defaultCacheName, nodes = RedisHost( localhost, 7000 ) :: RedisHost( localhost, 7001 ) :: RedisHost( localhostIp, 7002 ) :: RedisHost( localhostIp, 7003 ) :: Nil, defaults )
 
   private val connector: RedisConnector = new RedisConnectorProvider( clusterInstance, serializer ).get
 


### PR DESCRIPTION
Redis cluster implementation compares addresses of the internal (which is IP) and expected (which is given). When the given is a hostname and the internal is an IP, it never matches and cluster shuts down.