### PR TITLE
Use java8 Base64 implementation for jdk10 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Changelog
 
+### [:link: 2.1.2](https://github.com/KarelCemus/play-redis/tree/2.1.2)
+
+JDK 10 compatibility. Replace deprecated com.sun.misc.BASE64* usages with jdk8 java.util.Base64 [#170](https://github.com/KarelCemus/play-redis/pull/170).
+
 ### [:link: 2.1.1](https://github.com/KarelCemus/play-redis/tree/2.1.1)
 
 Scope of the Mockito dependency is set to Test, was Compile [#168](https://github.com/KarelCemus/play-redis/issues/168).

--- a/src/main/scala/play/api/cache/redis/connector/AkkaSerializer.scala
+++ b/src/main/scala/play/api/cache/redis/connector/AkkaSerializer.scala
@@ -1,13 +1,13 @@
 package play.api.cache.redis.connector
 
-import javax.inject._
+import java.util.Base64
 
+import javax.inject._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util._
 
 import play.api.cache.redis._
-
 import akka.actor.ActorSystem
 import akka.serialization._
 
@@ -72,7 +72,7 @@ private[ connector ] class AkkaEncoder( serializer: Serialization ) {
 
   /** Produces BASE64 encoded string from an array of bytes */
   protected def binaryToString( bytes: Array[ Byte ] ): String =
-    new sun.misc.BASE64Encoder( ).encode( bytes )
+    Base64.getEncoder.encodeToString( bytes )
 
   /** unsafe method converting AnyRef into BASE64 string */
   protected def anyRefToString( value: AnyRef ): String =
@@ -117,7 +117,7 @@ private[ connector ] class AkkaDecoder( serializer: Serialization ) {
 
   /** consumes BASE64 string and returns array of bytes */
   protected def stringToBinary( base64: String ): Array[ Byte ] =
-    new sun.misc.BASE64Decoder( ).decodeBuffer( base64 )
+    Base64.getDecoder.decode( base64 )
 
   /** deserializes the binary stream into the object */
   protected def binaryToAnyRef[ T ]( binary: Array[ Byte ] )( implicit classTag: ClassTag[ T ] ): AnyRef =

--- a/src/test/scala/play/api/cache/redis/connector/SerializerSpecs.scala
+++ b/src/test/scala/play/api/cache/redis/connector/SerializerSpecs.scala
@@ -71,7 +71,7 @@ class SerializerSpecs extends Specification with Mockito {
           |TG9yZy9qb2RhL3RpbWUvQ2hyb25vbG9neTt4cAAAAAAAAeJAc3IAJ29yZy5qb2RhLnRpbWUuY2hy
           |b25vLklTT0Nocm9ub2xvZ3kkU3R1YqnIEWZxN1AnAwAAeHBzcgAfb3JnLmpvZGEudGltZS5EYXRl
           |VGltZVpvbmUkU3R1YqYvAZp8MhrjAwAAeHB3BQADVVRDeHg=
-        """.stripMargin.trim
+        """.stripMargin.lines.map(_.trim).mkString
     }
 
     "custom classes" in {
@@ -79,7 +79,7 @@ class SerializerSpecs extends Specification with Mockito {
           |rO0ABXNyADtwbGF5LmFwaS5jYWNoZS5yZWRpcy5jb25uZWN0b3IuU2VyaWFsaXplclNwZWNzJFNp
           |bXBsZU9iamVjdMm6wvThiaEsAgACSQAFdmFsdWVMAANrZXl0ABJMamF2YS9sYW5nL1N0cmluZzt4
           |cAAAAAN0AAFC
-        """.stripMargin.trim
+        """.stripMargin.lines.map(_.trim).mkString
     }
 
     "null" in {
@@ -91,7 +91,7 @@ class SerializerSpecs extends Specification with Mockito {
           |rO0ABXNyADJzY2FsYS5jb2xsZWN0aW9uLmltbXV0YWJsZS5MaXN0JFNlcmlhbGl6YXRpb25Qcm94
           |eQAAAAAAAAABAwAAeHB0AAFBdAABQnQAAUNzcgAsc2NhbGEuY29sbGVjdGlvbi5pbW11dGFibGUu
           |TGlzdFNlcmlhbGl6ZUVuZCSKXGNb91MLbQIAAHhweA==
-        """.stripMargin.trim
+        """.stripMargin.lines.map(_.trim).mkString
     }
 
   }
@@ -151,7 +151,7 @@ class SerializerSpecs extends Specification with Mockito {
         |TG9yZy9qb2RhL3RpbWUvQ2hyb25vbG9neTt4cAAAAAAAAeJAc3IAJ29yZy5qb2RhLnRpbWUuY2hy
         |b25vLklTT0Nocm9ub2xvZ3kkU3R1YqnIEWZxN1AnAwAAeHBzcgAfb3JnLmpvZGEudGltZS5EYXRl
         |VGltZVpvbmUkU3R1YqYvAZp8MhrjAwAAeHB3BQADVVRDeHg=
-      """.stripMargin.trim.decoded[ DateTime ] mustEqual new DateTime( 123456L, DateTimeZone.forID( "UTC" ) )
+      """.stripMargin.lines.map(_.trim).mkString.decoded[ DateTime ] mustEqual new DateTime( 123456L, DateTimeZone.forID( "UTC" ) )
     }
 
     "custom classes" in {
@@ -159,7 +159,7 @@ class SerializerSpecs extends Specification with Mockito {
         |rO0ABXNyADtwbGF5LmFwaS5jYWNoZS5yZWRpcy5jb25uZWN0b3IuU2VyaWFsaXplclNwZWNzJFNp
         |bXBsZU9iamVjdMm6wvThiaEsAgACSQAFdmFsdWVMAANrZXl0ABJMamF2YS9sYW5nL1N0cmluZzt4
         |cAAAAAN0AAFC
-      """.stripMargin.trim.decoded[ SimpleObject ] mustEqual SimpleObject( "B", 3 )
+      """.stripMargin.lines.map(_.trim).mkString.decoded[ SimpleObject ] mustEqual SimpleObject( "B", 3 )
     }
 
     "list" in {
@@ -167,7 +167,7 @@ class SerializerSpecs extends Specification with Mockito {
         |rO0ABXNyADJzY2FsYS5jb2xsZWN0aW9uLmltbXV0YWJsZS5MaXN0JFNlcmlhbGl6YXRpb25Qcm94
         |eQAAAAAAAAABAwAAeHB0AAFBdAABQnQAAUNzcgAsc2NhbGEuY29sbGVjdGlvbi5pbW11dGFibGUu
         |TGlzdFNlcmlhbGl6ZUVuZCSKXGNb91MLbQIAAHhweA==
-      """.stripMargin.trim.decoded[ List[ String ] ] mustEqual List( "A", "B", "C" )
+      """.stripMargin.lines.map(_.trim).mkString.decoded[ List[ String ] ] mustEqual List( "A", "B", "C" )
     }
 
     "forgotten type" in {


### PR DESCRIPTION
- Adjust tests to explicitly join base64 strings prior to comparison