### PR TITLE
UPDATE: adding the PTTL the command that returns the remaining time t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ rebel.xml
 
 # OS-specific files
 .DS_Store
+
+INST

--- a/src/main/scala/play/api/cache/redis/CacheApi.scala
+++ b/src/main/scala/play/api/cache/redis/CacheApi.scala
@@ -171,7 +171,7 @@ private[redis] trait AbstractCacheApi[Result[_]] {
     * @param key        cache storage key
     * @return the remaining time to live of a key in milliseconds
     */
-  def pttl(key: String): Future[Long]
+  def pttl(key: String): Result[Long]
 
   /**
     * Remove a value under the given key from the cache

--- a/src/main/scala/play/api/cache/redis/CacheApi.scala
+++ b/src/main/scala/play/api/cache/redis/CacheApi.scala
@@ -166,6 +166,14 @@ private[redis] trait AbstractCacheApi[Result[_]] {
   def expire(key: String, expiration: Duration): Result[Done]
 
   /**
+    * returns the remaining time to live of a key that has an expire set, useful, e.g., when we want to check remaining session duration
+    *
+    * @param key        cache storage key
+    * @return the remaining time to live of a key in milliseconds
+    */
+  def pttl(key: String): Future[Long]
+
+  /**
     * Remove a value under the given key from the cache
     *
     * @param key cache storage key

--- a/src/main/scala/play/api/cache/redis/connector/RedisConnector.scala
+++ b/src/main/scala/play/api/cache/redis/connector/RedisConnector.scala
@@ -85,6 +85,14 @@ private[redis] trait CoreCommands {
   def expire(key: String, expiration: Duration): Future[Unit]
 
   /**
+    * returns the remaining time to live of a key that has an expire set, useful, e.g., when we want to check remaining session duration
+    *
+    * @param key        cache storage key
+    * @return the remaining time to live of a key in milliseconds
+    */
+  def pttl(key: String): Future[Long]
+
+  /**
     * Removes all keys in arguments. The other remove methods are for syntax sugar
     *
     * @param keys cache storage keys

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -103,7 +103,7 @@ private[impl] class RedisCache[Result[_]](redis: RedisConnector, builder: Builde
   }
 
   def pttl(key: String) = key.prefixed { key =>
-    redis.pttl(key)
+    redis.pttl(key).recoverWithDefault(0)
   }
 
   def increment(key: String, by: Long) = key.prefixed { key =>

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -103,7 +103,7 @@ private[impl] class RedisCache[Result[_]](redis: RedisConnector, builder: Builde
   }
 
   def pttl(key: String) = key.prefixed { key =>
-    redis.pttl(key).recoverWithDefault(0)
+    redis.pttl(key).recoverWithDefault(-2)
   }
 
   def increment(key: String, by: Long) = key.prefixed { key =>

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -103,7 +103,7 @@ private[impl] class RedisCache[Result[_]](redis: RedisConnector, builder: Builde
   }
 
   def pttl(key: String) = key.prefixed { key =>
-    redis.pttl(key).recoverWithDefault(0)
+    redis.pttl(key)
   }
 
   def increment(key: String, by: Long) = key.prefixed { key =>

--- a/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
+++ b/src/main/scala/play/api/cache/redis/impl/RedisCache.scala
@@ -102,6 +102,10 @@ private[impl] class RedisCache[Result[_]](redis: RedisConnector, builder: Builde
     redis.exists(key).recoverWithDefault(false)
   }
 
+  def pttl(key: String) = key.prefixed { key =>
+    redis.pttl(key).recoverWithDefault(0)
+  }
+
   def increment(key: String, by: Long) = key.prefixed { key =>
     redis.increment(key, by).recoverWithDefault(by)
   }


### PR DESCRIPTION
Available since 2.6.0.

Time complexity: O(1)

Like TTL this command returns the remaining time to live of a key that has an expire set, with the sole difference that TTL returns the amount of remaining time in seconds while PTTL returns it in milliseconds.

In Redis 2.6 or older the command returns -1 if the key does not exist or if the key exist but has no associated expire.

Starting with Redis 2.8 the return value in case of error changed:

The command returns -2 if the key does not exist.
The command returns -1 if the key exists but has no associated expire.
Return value
Integer reply: TTL in milliseconds, or a negative value in order to signal an error (see the description above).


Example:

```redis> SET mykey "Hello"
"OK"
redis> EXPIRE mykey 1
(integer) 1
redis> PTTL mykey
(integer) 999
redis> 
```