### PR TITLE
Update to play 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,9 @@ env:
 
 jobs:
   include:
-    - name: "Test Scala 2.11"
-      env:
-        - SCALA_VERSION=2.11.12
-        - SCRIPT=test
     - name: "Test Scala 2.12"
       env:
-        - SCALA_VERSION=2.12.9
+        - SCALA_VERSION=2.12.10
         - SCRIPT=test
     - name: "Test Scala 2.13"
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## Changelog
 
+### [:link: 2.6.0](https://github.com/KarelCemus/play-redis/tree/2.6.0)
+
+Update to Play `2.8.0`, dropped `Scala 2.11` since it was discontinued from the Play framework.
+Credits to Tomofumi Tanaka. [#225](https://github.com/KarelCemus/play-redis/pull/225)
+
 ### [:link: 2.5.1](https://github.com/KarelCemus/play-redis/tree/2.5.1)
 
 Java interop: Changed internal manifest for `null` values from `""` to `"null"` since

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   # Redis Cache module for Play framework
 
-  **This version supports Play framework 2.7.x with JDK 8 and both Scala 2.11, Scala 2.12 and Scala 2.13.**<br/>
+  **This version supports Play framework 2.8.x with JDK 8 and both Scala 2.12 and Scala 2.13.**<br/>
   **For previous versions see older releases.**
 
   [![Travis CI: Status](https://travis-ci.org/KarelCemus/play-redis.svg?branch=master)](https://travis-ci.org/KarelCemus/play-redis)
@@ -15,7 +15,7 @@
 ## About the Project
 
 [Play framework 2](https://playframework.com/) is delivered with
-[SyncCacheApi and AsyncCacheApi](https://playframework.com/documentation/2.7.x/ScalaCache).
+[SyncCacheApi and AsyncCacheApi](https://playframework.com/documentation/2.8.x/ScalaCache).
 This module provides **implementation of a cache over Redis** server, i.e., key/value storage.
 
 Besides the compatibility with all Play's cache APIs,
@@ -132,6 +132,7 @@ libraryDependencies += "com.github.karelcemus" %% "play-redis" % "2.5.1"
 
 | play framework  | play-redis     | documentation    |
 |-----------------|---------------:|-----------------:|
+| 2.8.x           | <!-- Play 2.8 -->2.5.1<!-- / -->          | [see here](https://github.com/KarelCemus/play-redis/blob/2.5.1/README.md) |
 | 2.7.x           | <!-- Play 2.7 -->2.5.1<!-- / -->          | [see here](https://github.com/KarelCemus/play-redis/blob/2.5.1/README.md) |
 | 2.6.x           | <!-- Play 2.6 -->2.3.0<!-- / -->          | [see here](https://github.com/KarelCemus/play-redis/blob/2.3.0/README.md) ([Migration Guide](https://github.com/KarelCemus/play-redis/blob/2.3.0/doc/40-migration.md)) |
 | 2.5.x           | <!-- Play 2.5 -->1.4.2<!-- / -->          | [see here](https://github.com/KarelCemus/play-redis/blob/1.4.2/README.md) |

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,11 @@ description := "Redis cache plugin for the Play framework 2"
 
 organization := "com.github.karelcemus"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq( "2.11.12", "2.12.10", scalaVersion.value )
+crossScalaVersions := Seq( "2.12.10", scalaVersion.value )
 
-playVersion := "2.7.3"
+playVersion := "2.8.0"
 
 connectorVersion := "1.9.1"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.5

--- a/src/main/scala/play/api/cache/redis/impl/AsyncJavaRedis.scala
+++ b/src/main/scala/play/api/cache/redis/impl/AsyncJavaRedis.scala
@@ -41,13 +41,14 @@ private[impl] class AsyncJavaRedis(internal: CacheAsyncApi)(implicit environment
     internal.remove(key, classTagKey(key)).asJava
   }
 
-  def get[T](key: String): CompletionStage[T] = getOrElse[T](key, None)
-
-  def getOptional[T](key: String): CompletionStage[Optional[T]] = {
+  def get[T](key: String): CompletionStage[Optional[T]] = {
     async { implicit context =>
       getOrElseOption[T](key, None).map(_.asJava)
     }
   }
+
+  @deprecated(message = "Method `getOptional` was deprecated in Play 2.8. Use `get` instead.", since = "2.6.0")
+  override def getOptional[T](key: String): CompletionStage[Optional[T]] = get(key)
 
   def getOrElse[T](key: String, block: Callable[T]): CompletionStage[T] =
     getOrElseUpdate[T](key, (() => Future.successful(block.call()).asJava).asJava)
@@ -96,7 +97,7 @@ private[impl] class AsyncJavaRedis(internal: CacheAsyncApi)(implicit environment
     }
   }
 
-  def removeAll() = internal.invalidate().asJava
+  def removeAll(): CompletionStage[Done] = internal.invalidate().asJava
 
   def exists(key: String): CompletionStage[java.lang.Boolean] = {
     async { implicit context =>

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -7,6 +7,13 @@ akka {
   log-dead-letters-during-shutdown = off
 
   actor {
+    # Akka 2.6 disables Java serialization by default
+    # and it must be explicitly enabled
+    #
+    # Java serialization is used in tests for its simplicity
+    # and easy setup
+    allow-java-serialization = on
+
     # disables warning
     warn-about-java-serializer-usage = off
   }

--- a/src/test/scala/play/api/cache/redis/RedisCacheModuleSpec.scala
+++ b/src/test/scala/play/api/cache/redis/RedisCacheModuleSpec.scala
@@ -31,6 +31,7 @@ class RedisCacheModuleSpec extends Specification {
       injector.instanceOf[CacheAsyncApi] must beAnInstanceOf[CacheAsyncApi]
       injector.instanceOf[play.cache.AsyncCacheApi] must beAnInstanceOf[play.cache.AsyncCacheApi]
       injector.instanceOf[play.cache.SyncCacheApi] must beAnInstanceOf[play.cache.SyncCacheApi]
+      injector.instanceOf[play.cache.redis.AsyncCacheApi] must beAnInstanceOf[play.cache.redis.AsyncCacheApi]
       injector.instanceOf[play.api.cache.AsyncCacheApi] must beAnInstanceOf[play.api.cache.AsyncCacheApi]
       injector.instanceOf[play.api.cache.SyncCacheApi] must beAnInstanceOf[play.api.cache.SyncCacheApi]
     }

--- a/src/test/scala/play/api/cache/redis/impl/AsyncJavaRedisSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/AsyncJavaRedisSpec.scala
@@ -21,18 +21,18 @@ class AsyncJavaRedisSpec(implicit ee: ExecutionEnv) extends Specification with R
 
     "get and miss" in new MockedJavaRedis {
       async.get[String](anyString)(anyClassTag) returns None
-      cache.get[String](key).asScala must beNull.await
+      cache.get[String](key).asScala must beEqualTo(Optional.empty).await
     }
 
     "get and hit" in new MockedJavaRedis {
       async.get[String](beEq(key))(anyClassTag) returns Some(value)
       async.get[String](beEq(classTagKey))(anyClassTag) returns Some(classTag)
-      cache.get[String](key).asScala must beEqualTo(value).await
+      cache.get[String](key).asScala must beEqualTo(Optional.of(value)).await
     }
 
     "get null" in new MockedJavaRedis {
       async.get[String](beEq(classTagKey))(anyClassTag) returns Some("null")
-      cache.get[String](key).asScala must beNull.await
+      cache.get[String](key).asScala must beEqualTo(Optional.empty).await
       there was one(async).get[String](classTagKey)
     }
 
@@ -134,7 +134,7 @@ class AsyncJavaRedisSpec(implicit ee: ExecutionEnv) extends Specification with R
       // hit on GET
       async.get[Byte](beEq(key))(anyClassTag) returns Some(byte)
       async.get[String](beEq(classTagKey))(anyClassTag) returns Some("java.lang.Byte")
-      cache.get[Byte](key).asScala must beEqualTo(byte).await
+      cache.get[Byte](key).asScala must beEqualTo(Optional.ofNullable(byte)).await
     }
 
     "get and set 'byte[]'" in new MockedJavaRedis {
@@ -148,7 +148,7 @@ class AsyncJavaRedisSpec(implicit ee: ExecutionEnv) extends Specification with R
       // hit on GET
       async.get[Array[Byte]](beEq(key))(anyClassTag) returns Some(bytes)
       async.get[String](beEq(classTagKey))(anyClassTag) returns Some("byte[]")
-      cache.get[Array[Byte]](key).asScala must beEqualTo(bytes).await
+      cache.get[Array[Byte]](key).asScala must beEqualTo(Optional.ofNullable(bytes)).await
     }
 
     "get all" in new MockedJavaRedis {


### PR DESCRIPTION
- Update to play 2.8
- Drop Scala 2.11 (support discontinued)
- Fix Deprecated  `AsyncCacheApi#getOptional` as of 2.8.0. Renamed to get(String)


