### PR TITLE
AsyncJavaRedis.remove now removes key and classTagKey in separate operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Changelog
 
+### [:link: 2.6.1](https://github.com/KarelCemus/play-redis/tree/2.6.1)
+
+Support of `DEL` operation in redis cluster [#230](https://github.com/KarelCemus/play-redis/issues/230)
+
 ### [:link: 2.6.0](https://github.com/KarelCemus/play-redis/tree/2.6.0)
 
 Update to Play `2.8.0`, dropped `Scala 2.11` since it was discontinued from the Play framework.

--- a/src/main/scala/play/api/cache/redis/impl/AsyncJavaRedis.scala
+++ b/src/main/scala/play/api/cache/redis/impl/AsyncJavaRedis.scala
@@ -38,7 +38,12 @@ private[impl] class AsyncJavaRedis(internal: CacheAsyncApi)(implicit environment
   }
 
   def remove(key: String): CompletionStage[Done] = {
-    internal.remove(key, classTagKey(key)).asJava
+    async { implicit context =>
+      Future.from(
+        internal.remove(key),
+        internal.remove(classTagKey(key))
+      ).asDone
+    }
   }
 
   def get[T](key: String): CompletionStage[Optional[T]] = {

--- a/src/test/scala/play/api/cache/redis/impl/AsyncJavaRedisSpec.scala
+++ b/src/test/scala/play/api/cache/redis/impl/AsyncJavaRedisSpec.scala
@@ -110,9 +110,10 @@ class AsyncJavaRedisSpec(implicit ee: ExecutionEnv) extends Specification with R
     }
 
     "remove" in new MockedJavaRedis {
-      async.remove(anyString, anyString, anyVarArgs) returns execDone
+      async.remove(anyString) returns execDone
       cache.remove(key).asScala must beDone.await
-      there was one(async).remove(key, classTagKey)
+      there was one(async).remove(key)
+      there was one(async).remove(classTagKey)
     }
 
     "remove all" in new MockedJavaRedis {


### PR DESCRIPTION
Fixes bug that produces the following error and causes cache to not be removed (issue #230)

```
play.api.cache.redis - Command DEL for key 'foo classTag::foo' failed.
redis.actors.ReplyErrorException: CROSSSLOT Keys in request don't hash to the same slot
        at redis.actors.RedisReplyDecoder.$anonfun$decodeRedisReply$1(RedisReplyDecoder.scala:68)
        at redis.actors.RedisReplyDecoder.$anonfun$decodeRedisReply$1$adapted(RedisReplyDecoder.scala:67)
        at redis.protocol.DecodeResult.foreach(RedisProtocolReply.scala:89)
        at redis.protocol.DecodeResult.foreach$(RedisProtocolReply.scala:87)
        at redis.protocol.FullyDecoded.foreach(RedisProtocolReply.scala:112)
```