### PR TITLE
Support RedisClientMasterSlaves

### DIFF
--- a/doc/20-configuration.md
+++ b/doc/20-configuration.md
@@ -10,7 +10,7 @@ There are several features supported in the configuration, they are discussed be
 
 This implementation supports both standalone and cluster instances. By default, the standalone mode is enabled.  It is configured like this:
 
-```
+```hocon
   play.cache.redis {
     host:       localhost
     # redis server: port
@@ -26,7 +26,7 @@ This implementation supports both standalone and cluster instances. By default, 
 
 To enable cluster mode instead, use `source` property. Valid values are `standalone` (default), `cluster`, `connection-string`, and `custom`. For more details, see below. Example of cluster settings:
 
-```
+```hocon
 play.cache.redis {
   # enable cluster mode
   source: cluster
@@ -52,7 +52,7 @@ play.cache.redis {
 Some platforms such as Amazon AWS use a single DNS record to define a whole cluster. Such
 a domain name resolves to multiple IP addresses, which are nodes of a cluster.
 
-```
+```hocon
 play.cache.redis {
   instances {
     play {
@@ -68,7 +68,7 @@ play.cache.redis {
 Use `source: sentinel` to enable sentinel mode. Required parameters are
 `master_group_name: ...` and `sentinels: []`. An example of sentinel settings:
 
-```
+```hocon
 play.cache.redis {
     source: sentinel
 
@@ -96,6 +96,50 @@ play.cache.redis {
         {
             host: localhost
             port: 16382
+        }
+    ]
+}
+```
+
+## Master-Slaves
+
+Use `source: master-slaves` to enable master-slaves mode.
+In this mode write only to the master node and read from one of slaves node.
+Required parameters are `master: {...}` and `slaves: []`. An example of master-slaves settings:
+
+```hocon
+play.cache.redis {
+    source: master-slaves
+
+    # username to your redis hosts (optional)
+    username: some-username
+    # password to your redis hosts, use if not specified for a specific node (optional)
+    password: "my-password"
+    # number of your redis database, use if not specified for a specific node (optional)
+    database: 1 
+    
+    # master node
+    master: {
+        host: "localhost"
+        port: 6380
+        # number of your redis database on master (optional)
+        database: 1
+        # username on master host (optional)
+        username: some-username
+        # password on master host (optional)
+        password: something
+    }
+    # slave nodes
+    slaves: [
+        {
+            host: "localhost"
+            port: 6381
+            # number of your redis database on slave (optional)
+            database: 1
+            # username on slave host (optional)
+            username: some-username
+            # password on slave host (optional)
+            password: something
         }
     ]
 }
@@ -307,7 +351,7 @@ each instance uses `lazy` policy.
 
 ## Running in different environments
 
-This module can run in various environments, from the localhost through the Heroku to your own premise. Each of these has a possibly different configuration. For this purpose, there is a `source` property accepting 4 values: `standalone` (default), `cluster`, `connection-string`, and `custom`.
+This module can run in various environments, from the localhost through the Heroku to your own premise. Each of these has a possibly different configuration. For this purpose, there is a `source` property accepting 4 values: `standalone` (default), `cluster`, `connection-string`, `master-slaves` and `custom`.
 
 The `standalone` and `cluster` options are already explained. The latter two simplify the use in environments, where the connection cannot be written into the configuration file up front.
 
@@ -366,11 +410,11 @@ configuration, see the [official Pekko documentation](https://pekko.apache.org/d
 
 ### Instance-specific (can be locally overridden)
 
-| Key                                                      | Type     |                              Default | Description                                                                                                             |
-|----------------------------------------------------------|---------:|-------------------------------------:|-------------------------------------------------------------------------------------------------------------------------|
-| [play.cache.redis.source](#standalone-vs-cluster)        | String   |                         `standalone` | Defines the source of the configuration. Accepted values are `standalone`, `cluster`, `connection-string`, and `custom` |
-| [play.cache.redis.sync-timeout](#timeout)                | Duration |                                 `1s` | conversion timeout applied by `SyncAPI` to convert `Future[T]` to `T`                                                   |
-| [play.cache.redis.redis-timeout](#timeout)               | Duration |                               `null` | waiting for the response from redis server                                                                              |
-| [play.cache.redis.prefix](#namespace-prefix)             | String   |                               `null` | optional namespace, i.e., key prefix                                                                                    |
-| play.cache.redis.dispatcher                              | String   | `pekko.actor.default-dispatcher` | Pekko actor                                                                                                             |
-| [play.cache.redis.recovery](#recovery-policy)            | String   |                    `log-and-default` | Defines behavior when command execution fails. For accepted values and more see                                         |
+| Key                                                      | Type     |                              Default | Description                                                                                                                             |
+|----------------------------------------------------------|---------:|-------------------------------------:|-----------------------------------------------------------------------------------------------------------------------------------------|
+| [play.cache.redis.source](#standalone-vs-cluster)        | String   |                         `standalone` | Defines the source of the configuration. Accepted values are `standalone`, `cluster`, `connection-string`, `master-slaves` and `custom` |
+| [play.cache.redis.sync-timeout](#timeout)                | Duration |                                 `1s` | conversion timeout applied by `SyncAPI` to convert `Future[T]` to `T`                                                                   |
+| [play.cache.redis.redis-timeout](#timeout)               | Duration |                               `null` | waiting for the response from redis server                                                                                              |
+| [play.cache.redis.prefix](#namespace-prefix)             | String   |                               `null` | optional namespace, i.e., key prefix                                                                                                    |
+| play.cache.redis.dispatcher                              | String   | `pekko.actor.default-dispatcher` | Pekko actor                                                                                                                             |
+| [play.cache.redis.recovery](#recovery-policy)            | String   |                    `log-and-default` | Defines behavior when command execution fails. For accepted values and more see                                                         |

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -147,7 +147,49 @@ play.cache.redis {
   #   # note: To consider a 'connection-string' variable, set 'source'
   #   # to 'connection-string'.
   #   source:           connection-string
-  #  }
+  #
+  #   ##########################
+  #   # Master-Slaves mode
+  #   ##########################
+  #
+  #   # master node, required config
+  #   master: {
+  #       # required string, defining a host the master is running on
+  #       host:        localhost
+  #       # required integer, defining a port the master is running on
+  #       port:        6379
+  #       # number of your redis database on master (optional)
+  #       database: 1
+  #       # optional string, defines a username to use with "redis" as a fallback
+  #       username:   null
+  #       # password on master host (optional)
+  #       password: something
+  #   }
+  #
+  #   # list of slaves nodes is either [].
+  #   slaves: [
+  #      {
+  #          # required string, defining a host the slave is running on
+  #          host:        localhost
+  #          # required integer, defining a port the slave is running on
+  #          port:        6379
+  #          # number of your redis database on slave (optional)
+  #          database: 1
+  #          # optional string, defines a username to use with "redis" as a fallback
+  #          username:   null
+  #          # password on slave host (optional)
+  #          password: something
+  #      }
+  #   ]
+  #
+  #   # number of your redis database, use if not specified for a node (optional)
+  #   database: 1
+  #   # optional string, defines a username to use with "redis" as a fallback
+  #   username:   null
+  #   # password to your redis hosts, use if not specified for a node (optional)
+  #   password: something
+  #   # to enable the master-slaves, set 'source' variable to 'master-slaves'
+  #   source:           master-slaves
   # }
 
   # configuration source. This library supports multiple types of
@@ -163,6 +205,8 @@ play.cache.redis {
   #  - 'sentinel' mode indicates use of 'sentinels' variable defining nodes
   #  - 'connection-string' mode is usually used with PaaS as setup by the
   #      environment. It consideres 'connection-string' property.
+  #  - 'master-slaves' master-slave mode is used to write only to the master node
+  #      and read from one of slaves node. It consideres 'master-slaves' property.
   #  - 'custom' indicates that the user supplies his own RedisInstance configuration
   #
   # Default value is 'standalone'

--- a/src/main/scala/play/api/cache/redis/configuration/RedisInstance.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/RedisInstance.scala
@@ -143,3 +143,43 @@ object RedisSentinel {
     }
 
 }
+
+/**
+  * Type of Redis Instance - a master-slaves. It encapsulates common settings of
+  * the master and slaves nodes.
+  */
+sealed trait RedisMasterSlaves extends RedisInstance {
+
+  def master: RedisHost
+  def slaves: List[RedisHost]
+  def username: Option[String]
+  def password: Option[String]
+  def database: Option[Int]
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case that: RedisMasterSlaves => equalsAsInstance(that) && this.master === master && this.slaves === that.slaves
+    case _                       => false
+  }
+
+  /** to string */
+  override def toString: String = s"MasterSlaves[master=$master, slaves=${slaves mkString ","}]"
+}
+
+object RedisMasterSlaves {
+
+  def apply(name: String, master: RedisHost, slaves: List[RedisHost], settings: RedisSettings, username: Option[String] = None, password: Option[String] = None, database: Option[Int] = None): RedisMasterSlaves with RedisDelegatingSettings =
+    create(name, master, slaves, username, password, database, settings)
+
+  @inline
+  private def create(_name: String, _master: RedisHost, _slaves: List[RedisHost], _username: Option[String], _password: Option[String], _database: Option[Int], _settings: RedisSettings) =
+    new RedisMasterSlaves with RedisDelegatingSettings {
+      override val name: String = _name
+      override val master: RedisHost = _master
+      override val slaves: List[RedisHost] = _slaves
+      override val username: Option[String] = _username
+      override val password: Option[String] = _password
+      override val database: Option[Int] = _database
+      override val settings: RedisSettings = _settings
+    }
+
+}

--- a/src/main/scala/play/api/cache/redis/configuration/RedisInstanceProvider.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/RedisInstanceProvider.scala
@@ -58,6 +58,8 @@ private[configuration] object RedisInstanceProvider extends RedisConfigInstanceL
       case "aws-cluster"       => RedisInstanceAwsCluster
       // required static configuration of the sentinel using application.conf
       case "sentinel"          => RedisInstanceSentinel
+      // required static configuration of the master-slaves using application.conf
+      case "master-slaves"     => RedisInstanceMasterSlaves
       // required possibly environmental configuration of the standalone instance
       case "connection-string" => RedisInstanceEnvironmental
       // supplied custom configuration
@@ -158,6 +160,26 @@ private[configuration] object RedisInstanceSentinel extends RedisConfigInstanceL
         settings = RedisSettings.withFallback(defaults).load(config, path),
       ),
     )
+
+}
+
+/** Statically configures redis master-slaves. */
+private[configuration] object RedisInstanceMasterSlaves extends RedisConfigInstanceLoader[RedisInstanceProvider] {
+
+  import JavaCompatibilityBase._
+  import RedisConfigLoader._
+
+  def load(config: Config, path: String, instanceName: String)(implicit defaults: RedisSettings) = new ResolvedRedisInstance(
+    RedisMasterSlaves.apply(
+      name = instanceName,
+      master = RedisHost.load(config.getConfig(path / "master")),
+      slaves = config.getConfigList(path / "slaves").asScala.map(config => RedisHost.load(config)).toList,
+      username = config.getOption(path / "username", _.getString),
+      password = config.getOption(path / "password", _.getString),
+      database = config.getOption(path / "database", _.getInt),
+      settings = RedisSettings.withFallback(defaults).load(config, path),
+    ),
+  )
 
 }
 

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+services:
+  redis-master:
+    image: redis:latest
+    hostname: redis-master
+    ports:
+      - '6379:6379'
+
+  redis-slave:
+    image: redis:latest
+    hostname: redis-slave
+    ports:
+      - '6479:6379'
+    command: redis-server --slaveof redis-master 6379

--- a/src/test/scala/play/api/cache/redis/connector/RedisMasterSlavesSpec.scala
+++ b/src/test/scala/play/api/cache/redis/connector/RedisMasterSlavesSpec.scala
@@ -1,0 +1,93 @@
+package play.api.cache.redis.connector
+
+import org.apache.pekko.actor.ActorSystem
+import play.api.cache.redis.configuration.{RedisHost, RedisMasterSlaves, RedisSettings}
+import play.api.cache.redis.impl.{LazyInvocation, RedisRuntime}
+import play.api.cache.redis.test.{Helpers, IntegrationSpec, RedisMasterSlaveContainer, StoppableApplication}
+import play.api.cache.redis.{LogAndFailPolicy, RedisConnector}
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
+
+class RedisMasterSlavesSpec extends IntegrationSpec with RedisMasterSlaveContainer {
+
+  override protected def testTimeout: FiniteDuration = 60.seconds
+
+  test("pong on ping") { connector =>
+    for {
+      _ <- connector.ping().assertingSuccess
+    } yield Passed
+  }
+
+  test("miss on get") { connector =>
+    for {
+      _ <- connector.get[String]("miss-on-get").assertingEqual(None)
+    } yield Passed
+  }
+
+  test("hit after set") { connector =>
+    for {
+      _ <- connector.set("hit-after-set", "value").assertingEqual(true)
+      _ <- connector.get[String]("hit-after-set").assertingEqual(Some("value"))
+    } yield Passed
+  }
+
+  test("ignore set if not exists when already defined") { connector =>
+    for {
+      _ <- connector.set("if-not-exists-when-exists", "previous").assertingEqual(true)
+      _ <- connector.set("if-not-exists-when-exists", "value", ifNotExists = true).assertingEqual(false)
+      _ <- connector.get[String]("if-not-exists-when-exists").assertingEqual(Some("previous"))
+    } yield Passed
+  }
+
+  test("perform set if not exists when undefined") { connector =>
+    for {
+      _ <- connector.get[String]("if-not-exists").assertingEqual(None)
+      _ <- connector.set("if-not-exists", "value", ifNotExists = true).assertingEqual(true)
+      _ <- connector.get[String]("if-not-exists").assertingEqual(Some("value"))
+      _ <- connector.set("if-not-exists", "other", ifNotExists = true).assertingEqual(false)
+      _ <- connector.get[String]("if-not-exists").assertingEqual(Some("value"))
+    } yield Passed
+  }
+
+  test("perform set if not exists with expiration") { connector =>
+    for {
+      _ <- connector.get[String]("if-not-exists-with-expiration").assertingEqual(None)
+      _ <- connector.set("if-not-exists-with-expiration", "value", 300.millis, ifNotExists = true).assertingEqual(true)
+      _ <- connector.get[String]("if-not-exists-with-expiration").assertingEqual(Some("value"))
+      // wait until the first duration expires
+      _ <- Future.after(700.millis, ())
+      _ <- connector.get[String]("if-not-exists-with-expiration").assertingEqual(None)
+    } yield Passed
+  }
+
+  def test(name: String)(f: RedisConnector => Future[Assertion]): Unit =
+    name in {
+      implicit val system: ActorSystem = ActorSystem("test", classLoader = Some(getClass.getClassLoader))
+      implicit val runtime: RedisRuntime = RedisRuntime("master-slaves", syncTimeout = 5.seconds, ExecutionContext.global, new LogAndFailPolicy, LazyInvocation)
+      implicit val application: StoppableApplication = StoppableApplication(system)
+      val serializer = new PekkoSerializerImpl(system)
+
+      lazy val masterSlavesInstance = RedisMasterSlaves(
+        name = "master-slaves",
+        master = RedisHost(host, masterPort),
+        slaves = List(RedisHost(host, slavePort)),
+        settings = RedisSettings.load(
+          config = Helpers.configuration.default.underlying,
+          path = "play.cache.redis",
+        ),
+      )
+
+      application.runAsyncInApplication {
+        val connector: RedisConnector = new RedisConnectorProvider(masterSlavesInstance, serializer).get
+        for {
+          // initialize the connector by flushing the database
+          keys <- connector.matching("*")
+          _    <- Future.sequence(keys.map(connector.remove(_)))
+          // run the test
+          _    <- f(connector)
+        } yield Passed
+      }
+    }
+
+}

--- a/src/test/scala/play/api/cache/redis/test/RedisMasterSlaveContainer.scala
+++ b/src/test/scala/play/api/cache/redis/test/RedisMasterSlaveContainer.scala
@@ -1,0 +1,33 @@
+package play.api.cache.redis.test
+
+import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService, SingleContainer}
+import org.scalatest.Suite
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.io.File
+
+trait RedisMasterSlaveContainer extends ForAllTestContainer {
+  this: Suite =>
+
+  protected val host = "localhost"
+  protected val masterPort = 6379
+  protected val slavePort = 6479
+
+  private val composeContainerDef = DockerComposeContainer.Def(
+    new File("src/test/resources/docker-compose.yml"),
+    tailChildContainers = true,
+    exposedServices = Seq(
+      ExposedService("redis-master", masterPort, Wait.forLogMessage(".*Ready to accept connections tcp.*\\n", 1)),
+      ExposedService("redis-slave", slavePort, Wait.forLogMessage(".*MASTER <-> REPLICA sync: Finished with success.*\\n", 1)),
+    ),
+  )
+
+  private lazy val dockerComposeContainer: DockerComposeContainer = composeContainerDef.createContainer()
+
+  protected def newContainer: SingleContainer[?] =
+    throw new UnsupportedOperationException("Creating a single container is not supported.")
+
+  override def beforeAll(): Unit = dockerComposeContainer.start()
+
+  override def afterAll(): Unit = dockerComposeContainer.stop()
+}


### PR DESCRIPTION
In many cases, there is a need to write data to the master, and read from one of the slave nodes. The [rediscala](https://github.com/rediscala/rediscala) library supports such functionality using class `redis.RedisClientMasterSlaves`. I implemented support for `RedisClientMasterSlaves` by specifying the configuration `source: master-slaves`. Example:
```
play.cache.redis {
    source: master-slaves

    # username to your redis hosts (optional)
    username: some-username
    # password to your redis hosts, use if not specified for a specific node (optional)
    password: "my-password"
    # number of your redis database, use if not specified for a specific node (optional)
    database: 1 
    
    # master node
    master: {
        host: "localhost"
        port: 6380
        # number of your redis database on master (optional)
        database: 1
        # username on master host (optional)
        username: some-username
        # password on master host (optional)
        password: something
    }
    # slave nodes
    slaves: [
        {
            host: "localhost"
            port: 6381
            # number of your redis database on slave (optional)
            database: 1
            # username on slave host (optional)
            username: some-username
            # password on slave host (optional)
            password: something
        }
    ]
}
```