### PR TITLE
ACL support for 2.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,22 +16,21 @@ crossScalaVersions := Seq( "2.12.15", scalaVersion.value )
 
 playVersion := "2.8.13"
 
-connectorVersion := "1.9.1"
-
 specs2Version := "4.13.2"
 
 libraryDependencies ++= Seq(
   // play framework cache API
   "com.typesafe.play" %% "play-cache" % playVersion.value % Provided,
   // redis connector
-  "com.github.karelcemus" %% "rediscala" % connectorVersion.value,
+  "io.github.rediscala" %% "rediscala" % "1.13.0",
   // test framework
   "org.specs2" %% "specs2-core" % specs2Version.value % Test,
   // with mockito extension
   "org.specs2" %% "specs2-mock" % specs2Version.value % Test,
   // test module for play framework
   "com.typesafe.play" %% "play-specs2" % playVersion.value % Test
-)
+) ++ Seq("akka-actor-typed", "akka-protobuf-v3", "akka-serialization-jackson", "akka-slf4j", "akka-stream")
+  .map("com.typesafe.akka" %% _ % "2.6.19")
 
 resolvers ++= Seq(
   "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"

--- a/doc/20-configuration.md
+++ b/doc/20-configuration.md
@@ -17,6 +17,8 @@ This implementation supports both standalone and cluster instances. By default, 
     port:       6379
     # redis server: database number (optional)
     database:   0
+    # authentication username (optional) with "redis" as fallback
+    username:   null
     # authentication password (optional)
     password:   null
   }
@@ -36,6 +38,8 @@ play.cache.redis {
       host:        localhost
       # required integer, defining a port the node is running on
       port:        6379
+      # optional string, defines a username to use with "redis" as fallback
+      username:    null
       # optional string, defines a password to use
       password:    null
     }
@@ -74,6 +78,8 @@ play.cache.redis {
 
     # Number of your redis database (optional)
     database: 1
+    # Username to your redis hosts (optional)
+    userame: some-username
     # Password to your redis hosts (optional)
     password: something
 

--- a/project/CustomReleasePlugin.scala
+++ b/project/CustomReleasePlugin.scala
@@ -10,7 +10,6 @@ object CustomReleasePlugin extends AutoPlugin {
   object autoImport {
 
     val playVersion = settingKey[ String ]( "Version of Play framework" )
-    val connectorVersion = settingKey[ String ]( "Version redis connector" )
     val specs2Version = settingKey[ String ]( "Version of specs2 testing framework" )
 
     val authors = settingKey[ Seq[ String ] ]( "List of authors of the library" )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -69,6 +69,8 @@ play.cache.redis {
   #   port:       6379
   #   # redis server: database number
   #   database:   0
+  #   # when authentication is required, optinally can be provided a username, otherwise "redis" is used.
+  #   username:   null
   #   # when authentication is required, define the password. The argument is optional
   #   password:   null
   #
@@ -84,6 +86,8 @@ play.cache.redis {
   #       host:        localhost
   #       # required integer, defining a port the node is running on
   #       port:        6379
+  #       # optional string, defines a username to use with "redis" as a fallback
+  #       username:   null
   #       # optional string, defines a password to use
   #       password:    null
   #     }

--- a/src/main/scala/play/api/cache/redis/configuration/RedisHost.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/RedisHost.scala
@@ -14,6 +14,8 @@ trait RedisHost {
   def port: Int
   /** redis database identifier to work with */
   def database: Option[Int]
+  /** when enabled security, this returns username for the AUTH command */
+  def username: Option[String]
   /** when enabled security, this returns password for the AUTH command */
   def password: Option[String]
   // $COVERAGE-OFF$
@@ -21,13 +23,13 @@ trait RedisHost {
   override def equals(obj: scala.Any) = equalsAsHost(obj)
   /** trait-specific equals, invokable from children */
   protected def equalsAsHost(obj: scala.Any) = obj match {
-    case that: RedisHost => Equals.check(this, that)(_.host, _.port, _.database, _.password)
+    case that: RedisHost => Equals.check(this, that)(_.host, _.port, _.username, _.database, _.password)
     case _               => false
   }
   /** to string */
-  override def toString = (password, database) match {
-    case (Some(password), Some(database)) => s"redis://redis:$password@$host:$port?db=$database"
-    case (Some(password), None)           => s"redis://redis:$password@$host:$port"
+  override def toString: String = (password, database) match {
+    case (Some(password), Some(database)) => s"redis://${username.getOrElse("redis")}:$password@$host:$port?db=$database"
+    case (Some(password), None)           => s"redis://${username.getOrElse("redis")}:$password@$host:$port"
     case (None, Some(database))           => s"redis://$host:$port?db=$database"
     case (None, None)                     => s"redis://$host:$port"
   }
@@ -38,12 +40,13 @@ object RedisHost extends ConfigLoader[RedisHost] {
   import RedisConfigLoader._
 
   /** expected format of the environment variable */
-  private val ConnectionString = "redis://((?<user>[^:]+):(?<password>[^@]+)@)?(?<host>[^:]+):(?<port>[0-9]+)".r("auth", "user", "password", "host", "port")
+  private val ConnectionString = "redis://((?<username>[^:]+):(?<password>[^@]+)@)?(?<host>[^:]+):(?<port>[0-9]+)".r
 
   def load(config: Config, path: String): RedisHost = apply(
     host = config.getString(path / "host"),
     port = config.getInt(path / "port"),
     database = config.getOption(path / "database", _.getInt),
+    username = config.getOption(path / "username", _.getString),
     password = config.getOption(path / "password", _.getString)
   )
 
@@ -51,29 +54,31 @@ object RedisHost extends ConfigLoader[RedisHost] {
   def fromConnectionString(connectionString: String): RedisHost = ConnectionString findFirstMatchIn connectionString match {
     // read the environment variable and fill missing information from the local configuration file
     case Some(matcher) => new RedisHost {
-      val host = matcher.group("host")
-      val port = matcher.group("port").toInt
-      val database = None
-      val password = Option(matcher.group("password"))
+      override val host: String = matcher.group("host")
+      override val port: Int = matcher.group("port").toInt
+      override val database: Option[Nothing] = None
+      override val username: Option[String] = Option(matcher.group("username"))
+      override val password: Option[String] = Option(matcher.group("password"))
     }
     // unexpected format
     case None => throw new IllegalArgumentException(s"Unexpected format of the connection string: '$connectionString'. Expected format is 'redis://[user:password@]host:port'.")
   }
 
-  def apply(host: String, port: Int, database: Option[Int] = None, password: Option[String] = None): RedisHost =
-    create(host, port, database, password)
+  def apply(host: String, port: Int, database: Option[Int] = None, username: Option[String] = None, password: Option[String] = None): RedisHost =
+    create(host, port, database, username, password)
 
   /** hackish method to preserve nice names of parameters in apply */
-  @inline private def create(_host: String, _port: Int, _database: Option[Int], _password: Option[String]) = new RedisHost {
-    val host = _host
-    val port = _port
-    val database = _database
-    val password = _password
+  @inline private def create(_host: String, _port: Int, _database: Option[Int], _username: Option[String], _password: Option[String]) = new RedisHost {
+    override val host: String = _host
+    override val port: Int = _port
+    override val database: Option[Int] = _database
+    override val username: Option[String] = _username
+    override val password: Option[String] = _password
   }
 
   // $COVERAGE-OFF$
-  def unapply(host: RedisHost): Option[(String, Int, Option[Int], Option[String])] = {
-    Some((host.host, host.port, host.database, host.password))
+  def unapply(host: RedisHost): Option[(String, Int, Option[Int], Option[String], Option[String])] = {
+    Some((host.host, host.port, host.database, host.username, host.password))
   }
   // $COVERAGE-ON$
 }
@@ -84,8 +89,9 @@ object RedisHost extends ConfigLoader[RedisHost] {
   */
 trait RedisDelegatingHost extends RedisHost {
   def innerHost: RedisHost
-  def host = innerHost.host
-  def port = innerHost.port
-  def database = innerHost.database
-  def password = innerHost.password
+  override def host: String = innerHost.host
+  override def port: Int = innerHost.port
+  override def database: Option[Int] = innerHost.database
+  override def username: Option[String] = innerHost.username
+  override def password: Option[String] = innerHost.password
 }

--- a/src/main/scala/play/api/cache/redis/configuration/RedisInstance.scala
+++ b/src/main/scala/play/api/cache/redis/configuration/RedisInstance.scala
@@ -91,6 +91,7 @@ trait RedisSentinel extends RedisInstance {
 
   def sentinels: List[RedisHost]
   def masterGroup: String
+  def username: Option[String]
   def password: Option[String]
   def database: Option[Int]
 
@@ -103,23 +104,28 @@ trait RedisSentinel extends RedisInstance {
 
 object RedisSentinel {
 
-  def apply(name: String, masterGroup: String,
+  def apply(
+      name: String,
+      masterGroup: String,
       sentinels: List[RedisHost],
       settings: RedisSettings,
+      username: Option[String] = None,
       password: Option[String] = None,
-      database: Option[Int] = None): RedisSentinel with RedisDelegatingSettings =
-    create(name, masterGroup, password, database, sentinels, settings)
+      database: Option[Int] = None
+  ): RedisSentinel with RedisDelegatingSettings =
+    create(name, masterGroup, username, password, database, sentinels, settings)
 
   @inline
-  private def create(_name: String, _masterGroup: String, _password: Option[String], _database: Option[Int],
+  private def create(_name: String, _masterGroup: String, _username: Option[String], _password: Option[String], _database: Option[Int],
       _sentinels: List[RedisHost], _settings: RedisSettings) =
     new RedisSentinel with RedisDelegatingSettings {
-      val name = _name
-      val masterGroup = _masterGroup
-      val password = _password
-      val database = _database
-      val sentinels = _sentinels
-      val settings = _settings
+      override val name: String = _name
+      override val masterGroup: String = _masterGroup
+      override val username: Option[String] = _username
+      override val password: Option[String] = _password
+      override val database: Option[Int] = _database
+      override val sentinels: List[RedisHost] = _sentinels
+      override val settings: RedisSettings = _settings
     }
 
 }

--- a/src/test/scala/play/api/cache/redis/RedisCacheModuleSpec.scala
+++ b/src/test/scala/play/api/cache/redis/RedisCacheModuleSpec.scala
@@ -173,6 +173,7 @@ object RedisCacheModuleSpec {
     def host = localhost
     def port = defaultPort
     def database = None
+    def username = None
     def password = None
   }
 }

--- a/src/test/scala/play/api/cache/redis/configuration/RedisHostSpec.scala
+++ b/src/test/scala/play/api/cache/redis/configuration/RedisHostSpec.scala
@@ -9,6 +9,25 @@ class RedisHostSpec extends Specification {
 
   private implicit val loader = RedisHost
 
+  "host with database, username, and password" in new WithConfiguration(
+    """play.cache.redis {
+      |  host:     localhost
+      |  port:     6378
+      |  database: 1
+      |  username: my-user
+      |  password: something
+      |}
+    """
+  ) {
+    configuration.get[RedisHost]("play.cache.redis") mustEqual RedisHost(
+      host = "localhost",
+      port = 6378,
+      database = 1,
+      username = "my-user",
+      password = "something",
+    )
+  }
+
   "host with database and password" in new WithConfiguration(
     """
       |play.cache.redis {
@@ -34,7 +53,7 @@ class RedisHostSpec extends Specification {
   }
 
   "host from connection string" in {
-    RedisHost.fromConnectionString("redis://redis:something@localhost:6378") mustEqual RedisHost("localhost", 6378, password = "something")
+    RedisHost.fromConnectionString("redis://redis:something@localhost:6378") mustEqual RedisHost("localhost", 6378, username = "redis", password = "something")
     RedisHost.fromConnectionString("redis://localhost:6378") mustEqual RedisHost("localhost", 6378)
     // test invalid string
     RedisHost.fromConnectionString("redis:/localhost:6378") must throwA[IllegalArgumentException]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.7.0"
+ThisBuild / version := "2.7.1-SNAPSHOT"


### PR DESCRIPTION
Hello!
This PR inherits the 2.7.0 tag. I can't select this tag as the target branch, so I've temporarily selected master.
Some context...
In our project, we use version 2.7.0 of this library because it's compatible with Play 2.8.x.
One of my tasks required ACL support, which, unfortunately, our version doesn't have.
Since the code was written using the Lagom framework, which was discontinued in 2023 and is closely tied to Play 2.8.19, it's not possible to simply upgrade both Play and the library to a higher version.
That's why this modification was necessary.